### PR TITLE
feat: add contentType parameter to CloudResponse's send method

### DIFF
--- a/core/src/cloudContext.ts
+++ b/core/src/cloudContext.ts
@@ -41,7 +41,7 @@ export interface CloudContext {
   /** Telemetry Service */
   telemetry?: TelemetryService;
   /** Send response */
-  send: (body: any, status: number) => void;
+  send: (body: any, status: number, contentType?: string) => void;
   /** Signals the runtime that the handler has completed with an error */
   error?: (error: any, status: number) => void;
   /** Signals the runtime that the handler has completed */

--- a/core/src/cloudResponse.ts
+++ b/core/src/cloudResponse.ts
@@ -13,9 +13,9 @@ export interface CloudResponse {
    * Send response
    * @param body Body of response
    * @param status Status code for response
-   * @param callback Callback to call with response
+   * @param contentType ContentType to apply it to response
    */
-  send: (body: any, status: number, callback?: Function) => void;
+  send: (body: any, status: number, contentType?: string) => void;
 
   /**
    * Flushes final response and signals cloud provider runtime that request is complete


### PR DESCRIPTION
**feat: add contentType parameter to CloudResponse's send method**

We added the contentType parameter to CloudResponse's send method in order to support streaming file content to the HTTP response