### PR TITLE
feat: add contentType parameter to AWSResponse's send method

### DIFF
--- a/aws/package-lock.json
+++ b/aws/package-lock.json
@@ -1215,9 +1215,9 @@
       }
     },
     "@multicloud/sls-core": {
-      "version": "0.1.1-13",
-      "resolved": "https://registry.npmjs.org/@multicloud/sls-core/-/sls-core-0.1.1-13.tgz",
-      "integrity": "sha512-ozyiHcbSYR97pYjkF3Ow0thUhxjcjbSicwTkOYKyD9V1cs+5uHhAnaYhONRU68zjkr5YGPpvZ0fPjZ7vj8PHkA==",
+      "version": "0.1.1-20",
+      "resolved": "https://registry.npmjs.org/@multicloud/sls-core/-/sls-core-0.1.1-20.tgz",
+      "integrity": "sha512-Y5d36Q3vHAqDl59nq8Mnx/Kq3UYM308GLjj5BrqILR7DcK+1cV4djLr1N7mtMIiW1SDL9MbtNxOHw6Dwpl3sjg==",
       "requires": {
         "inversify": "5.0.1",
         "reflect-metadata": "0.1.13"

--- a/aws/package.json
+++ b/aws/package.json
@@ -33,7 +33,7 @@
   "author": "Microsoft Corporation, 7-Eleven & Serverless Inc",
   "license": "MIT",
   "dependencies": {
-    "@multicloud/sls-core": "^0.1.1-13",
+    "@multicloud/sls-core": "^0.1.1-20",
     "aws-sdk": "2.476.0",
     "inversify": "5.0.1",
     "reflect-metadata": "0.1.13"

--- a/aws/src/awsContext.test.ts
+++ b/aws/src/awsContext.test.ts
@@ -31,7 +31,7 @@ describe("AWS context", () => {
     context.res.send = jest.fn();
     context.send(body);
 
-    expect(context.res.send).toBeCalledWith(body, 200);
+    expect(context.res.send).toBeCalledWith(body, 200, undefined);
   });
 
   it("send() calls response.send() on httpTrigger with custom status", () => {
@@ -41,7 +41,7 @@ describe("AWS context", () => {
     context.res.send = jest.fn();
     context.send(body, 400);
 
-    expect(context.res.send).toHaveBeenCalledWith(body, 400);
+    expect(context.res.send).toHaveBeenCalledWith(body, 400, undefined);
   });
 
   it("send() calls context.done() to signal handler is complete", () => {
@@ -49,6 +49,19 @@ describe("AWS context", () => {
     context.send("test", 200);
 
     expect(context.done).toBeCalled();
+  });
+
+  it("when send() calls response.send() on httpTrigger with contentType", () => {
+    const context = createAwsContext(awsEvent, awsContext),
+      expectedContentType = "image/jpg",
+      expectedBody = "test",
+      expectedStatus = 200;
+
+    context.res = new AwsResponse(context);
+    context.res.send = jest.fn();
+
+    context.send(expectedBody, expectedStatus, expectedContentType);
+    expect(context.res.send).toBeCalledWith(expectedBody, expectedStatus, expectedContentType);
   });
 
   it("flush() calls response.flush() to call final AWS callback", () => {

--- a/aws/src/awsContext.ts
+++ b/aws/src/awsContext.ts
@@ -48,10 +48,11 @@ export class AwsContext implements CloudContext {
    * Send response from AWS Lambda
    * @param body Body of response
    * @param status Status code of response
+   * @param contentType ContentType to apply it to response
    */
-  public send(body: any, status: number = 200): void {
+  public send(body: any, status: number = 200, contentType?: string): void {
     if (this.res) {
-      this.res.send(body, status);
+      this.res.send(body, status, contentType);
     }
 
     this.done();


### PR DESCRIPTION
**feat: add contentType parameter to AWSResponse's send method**

We added the contentType parameter to AWSResponse's send method and added the contentType value to the header. We also added the extraParams property in order to set the isBase64Encoded to true when the body is a buffer.