### PR TITLE
feat: add contentType parameter to AzureResponse's send method

### DIFF
--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -1215,9 +1215,9 @@
       }
     },
     "@multicloud/sls-core": {
-      "version": "0.1.1-13",
-      "resolved": "https://registry.npmjs.org/@multicloud/sls-core/-/sls-core-0.1.1-13.tgz",
-      "integrity": "sha512-ozyiHcbSYR97pYjkF3Ow0thUhxjcjbSicwTkOYKyD9V1cs+5uHhAnaYhONRU68zjkr5YGPpvZ0fPjZ7vj8PHkA==",
+      "version": "0.1.1-20",
+      "resolved": "https://registry.npmjs.org/@multicloud/sls-core/-/sls-core-0.1.1-20.tgz",
+      "integrity": "sha512-Y5d36Q3vHAqDl59nq8Mnx/Kq3UYM308GLjj5BrqILR7DcK+1cV4djLr1N7mtMIiW1SDL9MbtNxOHw6Dwpl3sjg==",
       "requires": {
         "inversify": "5.0.1",
         "reflect-metadata": "0.1.13"

--- a/azure/package.json
+++ b/azure/package.json
@@ -34,7 +34,7 @@
   "license": "MIT",
   "dependencies": {
     "@azure/storage-blob": "10.3.0",
-    "@multicloud/sls-core": "^0.1.1-13",
+    "@multicloud/sls-core": "^0.1.1-20",
     "inversify": "5.0.1",
     "reflect-metadata": "0.1.13",
     "streamifier": "0.1.1"

--- a/azure/src/azureContext.test.ts
+++ b/azure/src/azureContext.test.ts
@@ -49,13 +49,13 @@ describe("Azure context", () => {
   });
 
   it("when send() calls response.send() on httpTrigger with custom status", () => {
-    const body = { message: "oh Crap!" };
+    const body = { message: "oh no!" };
     context.send(body, 400);
     expect(context.res.send).toBeCalledWith(body, 400, undefined);
   });
 
   it("when send() calls response.send() on httpTrigger with contentType", () => {
-    const body = { message: "oh Crap!" };
+    const body = { message: "oh no!" };
     const expectedContentType = "image/jpg";
 
     context.send(body, 200, expectedContentType);
@@ -63,7 +63,7 @@ describe("Azure context", () => {
   });
 
   it("send() calls runtime done() on fail status code", () => {
-    const body = { message: "oh Crap!" };
+    const body = { message: "oh no!" };
     context.send(body, 400);
     expect(context.done).toBeCalled();
   });
@@ -90,7 +90,7 @@ describe("Azure context", () => {
   it("logging calls should be redirect to Azure context", () => {
     console.log("hi");
     console.warn("whoa");
-    console.error("crap");
+    console.error("no");
     console.trace("verbose");
     console.debug("dbg");
     console.info("A-okay");
@@ -105,7 +105,7 @@ describe("Azure context", () => {
   it("logging calls redirect and be restored", () => {
     console.log("hi");
     console.warn("whoa");
-    console.error("crap");
+    console.error("no");
     console.trace("verbose");
     console.debug("dbg");
     console.info("A-okay");

--- a/azure/src/azureContext.test.ts
+++ b/azure/src/azureContext.test.ts
@@ -44,13 +44,22 @@ describe("Azure context", () => {
   it("when send() calls response.send() on httpTrigger", () => {
     const body = { message: "Hello World" };
     context.send(body);
-    expect(context.res.send).toBeCalledWith(body, 200);
+
+    expect(context.res.send).toBeCalledWith(body, 200, undefined);
   });
 
   it("when send() calls response.send() on httpTrigger with custom status", () => {
     const body = { message: "oh Crap!" };
     context.send(body, 400);
-    expect(context.res.send).toBeCalledWith(body, 400);
+    expect(context.res.send).toBeCalledWith(body, 400, undefined);
+  });
+
+  it("when send() calls response.send() on httpTrigger with contentType", () => {
+    const body = { message: "oh Crap!" };
+    const expectedContentType = "image/jpg";
+
+    context.send(body, 200, expectedContentType);
+    expect(context.res.send).toBeCalledWith(body, 200, expectedContentType);
   });
 
   it("send() calls runtime done() on fail status code", () => {
@@ -66,7 +75,7 @@ describe("Azure context", () => {
 
   it("send() with no params uses default values", () => {
     context.send();
-    expect(context.res.send).toBeCalledWith(null, 200);
+    expect(context.res.send).toBeCalledWith(null, 200, undefined);
   });
 
   it("flush() calls response.flush()", () => {

--- a/azure/src/azureContext.ts
+++ b/azure/src/azureContext.ts
@@ -51,11 +51,12 @@ export class AzureContext implements CloudContext {
    * Send response from Azure Function
    * @param body Body of response
    * @param status Status code of response
+   * @param contentType ContentType to apply it to response
    */
-  public send(body: any = null, status: number = 200): void {
+  public send(body: any = null, status: number = 200, contentType?: string): void {
     try {
       if (this.res) {
-        this.res.send(body, status);
+        this.res.send(body, status, contentType);
       }
 
       this.done();

--- a/azure/src/azureResponse.test.ts
+++ b/azure/src/azureResponse.test.ts
@@ -92,6 +92,16 @@ describe("Azure Response", () => {
     expect(azureContext.res.headers.get("Content-Type")).toEqual("application/json");
   });
 
+  it("should set content-type to content-type received for buffer", () => {
+    const azureContext = createAzureContext(defaultParams);
+    const expectedContentType = "image/jpg";
+
+    azureContext.res.send(new Buffer("hello"), 200, expectedContentType);
+
+    expect(azureContext.res.headers.has("Content-Type"));
+    expect(azureContext.res.headers.get("Content-Type")).toEqual(expectedContentType);
+  });
+
   it("should have status = 400", () => {
     const expectedStatusStatus = 400;
     const azureContext = createAzureContext(defaultParams);

--- a/azure/src/azureResponse.ts
+++ b/azure/src/azureResponse.ts
@@ -42,8 +42,9 @@ export class AzureResponse implements CloudResponse {
    * Send HTTP response
    * @param body Body of HTTP response
    * @param status Status code of HTTP response
+   * @param contentType ContentType to apply it to response
    */
-  public send(body: any = null, status: number = 200): void {
+  public send(body: any = null, status: number = 200, contentType?: string): void {
     // If body was left as `undefined` vs `null` the azure functions runtime
     // incorrectly returns the full `response` object as the `body` of the response object
     this.body = body;
@@ -54,6 +55,10 @@ export class AzureResponse implements CloudResponse {
     }
 
     const bodyType = body.constructor.name;
+
+    if (["Buffer"].includes(bodyType)) {
+      this.headers.set("Content-Type", contentType);
+    }
 
     if (["Object", "Array"].includes(bodyType)) {
       this.headers.set("Content-Type", "application/json");

--- a/core/src/cloudContext.ts
+++ b/core/src/cloudContext.ts
@@ -41,7 +41,7 @@ export interface CloudContext {
   /** Telemetry Service */
   telemetry?: TelemetryService;
   /** Send response */
-  send: (body: any, status: number) => void;
+  send: (body: any, status: number, contentType?: string) => void;
   /** Signals the runtime that the handler has completed with an error */
   error?: (error: any, status: number) => void;
   /** Signals the runtime that the handler has completed */

--- a/core/src/cloudResponse.ts
+++ b/core/src/cloudResponse.ts
@@ -13,9 +13,9 @@ export interface CloudResponse {
    * Send response
    * @param body Body of response
    * @param status Status code for response
-   * @param callback Callback to call with response
+   * @param contentType ContentType to apply it to response
    */
-  send: (body: any, status: number, callback?: Function) => void;
+  send: (body: any, status: number, contentType?: string) => void;
 
   /**
    * Flushes final response and signals cloud provider runtime that request is complete


### PR DESCRIPTION
**feat: add contentType parameter to AzureResponse's send method**

We added the contentType parameter to AzureResponse's send method and add the  contentType value to the header