### PR TITLE
feat: support Uint8Array object type in convertToStream method

### DIFF
--- a/core/src/common/util.test.ts
+++ b/core/src/common/util.test.ts
@@ -63,6 +63,15 @@ describe("util", () => {
       });
     });
 
+    it("receives a Uint8Array and returns a Stream", (done) => {
+      const actualStream = convertToStream(new Uint8Array(Buffer.from(input)));
+      streamToString(actualStream, (result) => {
+        expect(result).toEqual(input);
+        expect(actualStream).toBeInstanceOf(Readable);
+        done();
+      });
+    });
+
     it("throws an exception when input value is not string/Buffer/Stream", (done) => {
       const value = 100
       expect(() => convertToStream(value as unknown as string)).toThrowError();

--- a/core/src/common/util.ts
+++ b/core/src/common/util.ts
@@ -18,8 +18,12 @@ export function ensurePromise<T>(value: T | Promise<T>) {
  * Converts the input to Stream
  * @param input Data to be converted to Stream
  */
-export function convertToStream(input: string | Buffer | Stream): Readable {
+export function convertToStream(input: string | Buffer | Stream | Uint8Array): Readable {
   Guard.null(input, "input");
+
+  if (input instanceof Uint8Array) {
+    input = Buffer.from(input.buffer);
+  }
 
   let readable;
 


### PR DESCRIPTION
**Description**
Due getObject and putObject support from S3 support different type of objects (such as string, Stream, buffer and Uint8Array) we add the support to Uint8Array.

- [x] Support Uint8Array type to ConvertToStream method
- [x] Parse Uint8Array to Buffer
- [x] Add test case

| Added test case  | 
| ------------- | 
| ![image](https://user-images.githubusercontent.com/10620434/65076099-a63a9d80-d96e-11e9-8a57-45eb0348d4f3.png) | 
