### PR TITLE
feat: Exposes `context.error` method to signal an error has occurred during middleware pipeline

### DIFF
--- a/core/src/cloudContext.ts
+++ b/core/src/cloudContext.ts
@@ -42,7 +42,9 @@ export interface CloudContext {
   telemetry?: TelemetryService;
   /** Send response */
   send: (body: any, status: number) => void;
-  /** Signals the runtime that handler has completed */
+  /** Signals the runtime that the handler has completed with an error */
+  error?: (error: any, status: number) => void;
+  /** Signals the runtime that the handler has completed */
   done: () => void;
   /** Flushes the final response to the cloud providers */
   flush: () => void;

--- a/core/src/middleware/exceptionMiddleware.ts
+++ b/core/src/middleware/exceptionMiddleware.ts
@@ -16,7 +16,7 @@ export interface ExceptionOptions {
  */
 export const ExceptionMiddleware = (options: ExceptionOptions): Middleware =>
   (context: CloudContext, next: () => Promise<void>): Promise<void> => {
-    function onError(err) {
+    function onError(err: any, status: number = 500) {
       options.log(err);
 
       const result = {
@@ -25,10 +25,11 @@ export const ExceptionMiddleware = (options: ExceptionOptions): Middleware =>
         timestamp: new Date()
       };
 
-      context.send(result, 500);
+      context.send(result, status);
     }
 
     try {
+      context.error = onError;
       return next().catch(onError);
     } catch (err) {
       onError(err);


### PR DESCRIPTION
## What did you implement:
Adds the ability to manually call into the `ExceptionMiddleware` via a new `context.error(...)` method to set the error an optionally a status code.

Closes N/A

When working with callbacks (specifically async callbacks) throwing an error in an async handler cannot be handled by a typical try/catch block.  In this case we need a way to mark that an exception has occurred without having an unhanded exception silently bubble up the call stack and terminate the process.

## How did you implement it:
The `ExceptionMiddleware` sets `context.error` to its internal onError implementation.  Updated typescript interface to mark this as an optional method required on future implementations since the method is implemented outside the context itself.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it: 

Write a handler that throws an error inside a call to `setImmediate()`.  This will simulate the error condition.  This needs to be replaced with a call to `context.error({error || string)`

## Todos:

_**Note: Run `npm run test` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.
- [x] Write documentation
- [x] Ensure there are no lint errors.
- [x] Ensure introduced changes match Prettier formatting.
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
