### PR TITLE
feat: add headers params to azure service invoke method

### DIFF
--- a/azure/src/services/azureFunctionCloudService.test.ts
+++ b/azure/src/services/azureFunctionCloudService.test.ts
@@ -1,12 +1,17 @@
 import axios, { AxiosRequestConfig } from "axios";
-import { ContainerResolver, CloudContainer, CloudService } from "@multicloud/sls-core"
-import { AzureFunctionCloudService, AzureCloudServiceOptions } from "."
+import {
+  ContainerResolver,
+  CloudContainer,
+  CloudService,
+  StringParams
+} from "@multicloud/sls-core";
+import { AzureFunctionCloudService, AzureCloudServiceOptions } from ".";
 
 const getCartAzureCloudService: AzureCloudServiceOptions = {
   name: "azure-getCart",
   http: "test-url",
-  method: "GET",
-}
+  method: "GET"
+};
 
 describe("Azure Cloud Service should", () => {
   let container: CloudContainer;
@@ -18,9 +23,11 @@ describe("Azure Cloud Service should", () => {
     container = new CloudContainer();
     context = {
       container
-    }
+    };
     cloudService = new AzureFunctionCloudService(context);
-    container.bind(getCartAzureCloudService.name).toConstantValue(getCartAzureCloudService);
+    container
+      .bind(getCartAzureCloudService.name)
+      .toConstantValue(getCartAzureCloudService);
   });
 
   it("call axios.request with the configuration", async () => {
@@ -28,6 +35,7 @@ describe("Azure Cloud Service should", () => {
       url: "test-url",
       method: "GET",
       data: null,
+      headers: {}
     };
     axios.request = jest.fn().mockReturnValue(Promise.resolve());
     await cloudService.invoke<Promise<any>>("azure-getCart", false);
@@ -39,9 +47,13 @@ describe("Azure Cloud Service should", () => {
       url: "test-url",
       method: "GET",
       data: null,
+      headers: {}
     };
     axios.request = jest.fn().mockReturnValue(Promise.resolve("Response"));
-    const response = await cloudService.invoke<Promise<any>>("azure-getCart", false);
+    const response = await cloudService.invoke<Promise<any>>(
+      "azure-getCart",
+      false
+    );
     expect(axios.request).toBeCalledWith(axiosRequestConfig);
     expect(response).toEqual("Response");
   });
@@ -51,9 +63,13 @@ describe("Azure Cloud Service should", () => {
       url: "test-url",
       method: "GET",
       data: null,
+      headers: {}
     };
     axios.request = jest.fn().mockReturnValue(Promise.resolve("Response"));
-    const response = await cloudService.invoke<Promise<any>>("azure-getCart", true);
+    const response = await cloudService.invoke<Promise<any>>(
+      "azure-getCart",
+      true
+    );
     expect(axios.request).toBeCalledWith(axiosRequestConfig);
     expect(response).toBeUndefined();
   });
@@ -76,8 +92,24 @@ describe("Azure Cloud Service should", () => {
       url: "test-url",
       method: "GET",
       data: payload,
+      headers: {}
     };
     const response = cloudService.invoke("azure-getCart", false, payload);
+    expect(axios.request).toBeCalledWith(axiosRequestConfig);
+    expect(response).not.toBeNull();
+  });
+
+  it("makes request with headers when defined", async () => {
+    axios.request = jest.fn().mockReturnValue(Promise.resolve("Response"));
+    const headers = new StringParams({ key: 123 });
+
+    const axiosRequestConfig: AxiosRequestConfig = {
+      url: "test-url",
+      method: "GET",
+      data: null,
+      headers: headers.toJSON()
+    };
+    const response = cloudService.invoke("azure-getCart", false, null, headers);
     expect(axios.request).toBeCalledWith(axiosRequestConfig);
     expect(response).not.toBeNull();
   });
@@ -93,7 +125,7 @@ describe("Azure Cloud Service should", () => {
       resolve: <T>(): T => {
         return (EmptyContainer as unknown) as T;
       }
-    }
+    };
     context.container = newResolver;
     axios.request = jest.fn().mockReturnValue(Promise.resolve("Response"));
     const sut = new AzureFunctionCloudService(context);

--- a/azure/src/services/azureFunctionCloudService.ts
+++ b/azure/src/services/azureFunctionCloudService.ts
@@ -1,4 +1,10 @@
-import { CloudService, ContainerResolver, CloudServiceOptions, CloudContext } from "@multicloud/sls-core";
+import {
+  CloudService,
+  ContainerResolver,
+  CloudServiceOptions,
+  CloudContext,
+  StringParams
+} from "@multicloud/sls-core";
 import axios, { AxiosRequestConfig } from "axios";
 import { ComponentType } from "@multicloud/sls-core";
 import { injectable, inject } from "inversify";
@@ -20,12 +26,13 @@ export interface AzureCloudServiceOptions extends CloudServiceOptions {
  */
 @injectable()
 export class AzureFunctionCloudService implements CloudService {
-
   /**
    * Initialize a new Azure Function Cloud Service with the IoC container
    * @param containerResolver IoC container for service resolution
    */
-  public constructor(@inject(ComponentType.CloudContext) context: CloudContext) {
+  public constructor(
+    @inject(ComponentType.CloudContext) context: CloudContext
+  ) {
     this.containerResolver = context.container;
   }
 
@@ -37,12 +44,19 @@ export class AzureFunctionCloudService implements CloudService {
    * @param fireAndForget Wait for response if false (default behavior)
    * @param payload Body of HTTP request
    */
-  public async invoke<T>(name: string, fireAndForget = false, payload: any = null) {
+  public async invoke<T>(
+    name: string,
+    fireAndForget = false,
+    payload: any = null,
+    headers: StringParams = new StringParams()
+  ) {
     if (!name || name.length === 0) {
       throw Error("Name is needed");
     }
 
-    const context = this.containerResolver.resolve<AzureCloudServiceOptions>(name);
+    const context = this.containerResolver.resolve<AzureCloudServiceOptions>(
+      name
+    );
     if (!context.method || !context.http) {
       throw Error("Missing Data");
     }
@@ -51,10 +65,11 @@ export class AzureFunctionCloudService implements CloudService {
       url: context.http,
       method: context.method,
       data: payload,
+      headers: headers.toJSON()
     };
 
     if (fireAndForget) {
-      axios.request(axiosRequestConfig)
+      axios.request(axiosRequestConfig);
       return Promise.resolve(undefined);
     } else {
       return await axios.request<T>(axiosRequestConfig);


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

We added a headers parameter to AzureFunctionCloudService invoke method

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

We modified the AzureFunctionCloudService class in order to accept headers and add it to the axios options to make the HTTP request from Azure using the headers passed as parameters

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

_Unit tests_

![image](https://user-images.githubusercontent.com/11664783/66145034-53a0e880-e5e0-11e9-80a6-2771dfaf2d85.png)

_Test coverage_

![image](https://user-images.githubusercontent.com/11664783/66145074-6b786c80-e5e0-11e9-9dd0-c1e06b071d6e.png)


<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [X] Write tests and confirm existing functionality is not broken.
       **Validate via `npm test`**
- [ ] Write documentation
- [X] Ensure there are no lint errors.
       **Validate via `npm run lint-updated`**
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [X] Ensure introduced changes match Prettier formatting.
       **Validate via `npm run prettier-check-updated`**
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [X] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
