### PR TITLE
feat: set content-type to application/json by default on Azure

### DIFF
--- a/azure/src/azureResponse.test.ts
+++ b/azure/src/azureResponse.test.ts
@@ -62,6 +62,15 @@ describe("Azure Response", () => {
     expect(azureContext.res.headers.get("Content-Type")).toEqual("application/json");
   });
 
+  it("should set content-type to application/json by default", () => {
+    const azureContext = createAzureContext(defaultParams);
+
+    azureContext.res.send();
+
+    expect(azureContext.res.headers.has("Content-Type"));
+    expect(azureContext.res.headers.get("Content-Type")).toEqual("application/json");
+  });
+
   it("should set content-type to application/json for JSON objects", () => {
     const azureContext = createAzureContext(defaultParams);
 

--- a/azure/src/azureResponse.ts
+++ b/azure/src/azureResponse.ts
@@ -35,6 +35,7 @@ export class AzureResponse implements CloudResponse {
   ) {
     this.runtime = context.runtime;
     this.headers = new StringParams(this.runtime.context.res.headers);
+    this.headers.set("Content-Type", "application/json");
     this.headers.set(CloudProviderResponseHeader, ProviderType.Azure);
   }
 
@@ -58,10 +59,6 @@ export class AzureResponse implements CloudResponse {
 
     if (["Buffer"].includes(bodyType)) {
       this.headers.set("Content-Type", contentType);
-    }
-
-    if (["Object", "Array"].includes(bodyType)) {
-      this.headers.set("Content-Type", "application/json");
     }
 
     if (["String"].includes(bodyType)) {


### PR DESCRIPTION
## What did you implement:

We standardized the AzureResponse class to return an `application/json` on the `Content-Type` header when `send` method

## How did you implement it:

We modified the AzureResponse class to set the `Content-Type` as `application/json`. We removed the set in the `send` method due it's not necessary anymore. Also we created one more test.

## How can we verify it:

| Unit tests |
| ----------- |
| ![image](https://user-images.githubusercontent.com/10620434/66328015-36cb2480-e902-11e9-90d9-61aba80bbd0f.png) |

| Test coverage |
| ----------- |
| ![image](https://user-images.githubusercontent.com/10620434/66328122-69751d00-e902-11e9-89a6-478e81f5c55b.png) |

| Response of Postman |
|-------|
| ![image](https://user-images.githubusercontent.com/10620434/66335635-d04e0280-e911-11e9-9e8f-ea2cb3b733b5.png) |

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.
       **Validate via `npm test`**
- [ ] Write documentation
- [x] Ensure there are no lint errors.
       **Validate via `npm run lint-updated`**
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.
       **Validate via `npm run prettier-check-updated`**
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
