### PR TITLE
feat: set content-type to application/json by default on AWS

### DIFF
--- a/aws/src/awsResponse.test.ts
+++ b/aws/src/awsResponse.test.ts
@@ -26,6 +26,16 @@ describe("test of response", () => {
     expect(response.status).toEqual(httpStatus);
   });
 
+  it("should set content-type to application/json by default", () => {
+    const context = new AwsContext([{}, {}]);
+    const response = new AwsResponse(context);
+
+    response.send();
+
+    expect(response.headers.has("Content-Type"));
+    expect(response.headers.get("Content-Type")).toEqual("application/json");
+  });
+
   it("should set content-type to application/json for JSON objects", () => {
     const context = new AwsContext([{}, {}]);
     const response = new AwsResponse(context);

--- a/aws/src/awsResponse.ts
+++ b/aws/src/awsResponse.ts
@@ -34,6 +34,7 @@ export class AwsResponse implements CloudResponse {
    * @param context Current CloudContext
    */
   public constructor(@inject(ComponentType.CloudContext) context: AwsContext) {
+    this.headers.set("Content-Type", "application/json");
     this.headers.set(CloudProviderResponseHeader, ProviderType.AWS);
     this.callback = context.runtime.callback;
   }
@@ -44,7 +45,7 @@ export class AwsResponse implements CloudResponse {
    * @param status Status code of HTTP response
    * @param contentType ContentType to apply it to response
    */
-  public send(body: any, status: number = 200, contentType?: string): void {
+  public send(body: any = null, status: number = 200, contentType?: string): void {
     const responseBody = typeof (body) !== "string"
       ? JSON.stringify(body)
       : body;
@@ -62,10 +63,6 @@ export class AwsResponse implements CloudResponse {
       this.isBase64Encoded = true;
       this.body = (body as Buffer).toString("base64");
       this.headers.set("Content-Type", contentType);
-    }
-
-    if (["Object", "Array"].includes(bodyType)) {
-      this.headers.set("Content-Type", "application/json");
     }
 
     if (["String"].includes(bodyType)) {


### PR DESCRIPTION
## What did you implement:

We standardized the AWSResponse class to return an `application/json` on the `Content-Type` header when `send` method

## How did you implement it:

We modified the AwsResponse class to set the `Content-Type` as `application/json`. We removed the set in the `send` method due it's not necessary anymore. Also we created one more test.

## How can we verify it:

| Unit tests |
| -----------|
| ![image](https://user-images.githubusercontent.com/10620434/66333812-1f923400-e90e-11e9-989e-6b105d9644b2.png) |

| Test coverage |
| -----------|
| ![image](https://user-images.githubusercontent.com/10620434/66333715-ec4fa500-e90d-11e9-92bf-67b34553acec.png) |

| Response of Postman |
| -----------|
| ![image](https://user-images.githubusercontent.com/10620434/66335717-f5db0c00-e911-11e9-87a5-f4b92af9dc66.png) |

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.
       **Validate via `npm test`**
- [ ] Write documentation
- [x] Ensure there are no lint errors.
       **Validate via `npm run lint-updated`**
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.
       **Validate via `npm run prettier-check-updated`**
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
