### PR TITLE
fix: Update LambdaCloudService request and response

### DIFF
--- a/aws/src/services/lambdaCloudService.test.ts
+++ b/aws/src/services/lambdaCloudService.test.ts
@@ -1,6 +1,7 @@
 import AWS from "aws-sdk";
+import { Readable } from "stream";
 import { LambdaCloudService, AWSCloudServiceOptions, AWSInvokeType } from ".";
-import { CloudContainer } from "@multicloud/sls-core";
+import { CloudContainer, CloudContext, CloudContextBuilder, convertToStream } from "@multicloud/sls-core";
 
 jest.mock("aws-sdk");
 
@@ -8,88 +9,111 @@ const getCartAWSCloudService: AWSCloudServiceOptions = {
   name: "aws-getCart",
   region: "west-us-2",
   arn: "arn-west-us-2-getCart",
-}
+};
 
 describe("LambdaCloudService", () => {
-  let container: CloudContainer;
-  let context;
+  const container = new CloudContainer();
+  container.bind(getCartAWSCloudService.name).toConstantValue(getCartAWSCloudService);
 
-  beforeAll(() => {
-    container = new CloudContainer();
-    context = {
-      container
-    }
-    container.bind(getCartAWSCloudService.name).toConstantValue(getCartAWSCloudService);
+  const builder = new CloudContextBuilder();
+  const context: CloudContext = {
+    ...builder.build(),
+    container
+  };
+
+  const invokeResponseBody = {
+    foo: "bar"
+  };
+
+  let invokeResponse;
+  beforeEach(() => {
+    invokeResponse = convertToStream(
+      JSON.stringify({
+        body: JSON.stringify(invokeResponseBody)
+      })
+    );
 
     AWS.Lambda.prototype.invoke = jest.fn().mockReturnValue({
-      promise: jest.fn().mockReturnValue(Promise.resolve)
-    })
+      createReadStream: jest.fn().mockReturnValue(invokeResponse)
+    });
   });
 
   it("should create a Lambda instance", async () => {
     const sut = new LambdaCloudService(context);
-    await sut.invoke<Promise<any>>("aws-getCart", null, {});
+    await sut.invoke<any>("aws-getCart", null, {});
     expect(AWS.Lambda).toHaveBeenCalled();
-  })
+  });
 
   it("should be called as fireAndWait by default", async () => {
+    const payload = {};
     const options = {
-      FunctionName: "arn-west-us-2-getCart",
-      Payload: {},
+      FunctionName: getCartAWSCloudService.arn,
+      Payload: JSON.stringify({ body: payload }),
       InvocationType: AWSInvokeType.fireAndWait
-    }
+    };
 
     const sut = new LambdaCloudService(context);
-    await sut.invoke<Promise<any>>("aws-getCart", null, {});
+    await sut.invoke<any>("aws-getCart", null, payload);
     expect(AWS.Lambda.prototype.invoke).toHaveBeenCalledWith(options);
-  })
+  });
 
   it("should return an empty response on fireAndForget", async () => {
+    const payload = {};
     const options = {
-      FunctionName: "arn-west-us-2-getCart",
-      Payload: {},
+      FunctionName: getCartAWSCloudService.arn,
+      Payload: JSON.stringify({ body: payload }),
       InvocationType: AWSInvokeType.fireAndForget
-    }
-
-    AWS.Lambda.prototype.invoke = jest.fn().mockReturnValue({
-      promise: jest.fn().mockReturnValue(Promise.resolve({}))
-    })
+    };
 
     const sut = new LambdaCloudService(context);
-    const response = await sut.invoke<Promise<any>>("aws-getCart", true, {});
+    const response = await sut.invoke<any>("aws-getCart", true, payload);
     expect(AWS.Lambda.prototype.invoke).toHaveBeenCalledWith(options);
-    expect(response).toEqual({});
-  })
+    expect(response).toBeUndefined();
+  });
 
   it("should return data on fireAndWait", async () => {
+    const payload = {};
     const options = {
-      FunctionName: "arn-west-us-2-getCart",
-      Payload: {},
+      FunctionName: getCartAWSCloudService.arn,
+      Payload: JSON.stringify({ body: payload }),
       InvocationType: AWSInvokeType.fireAndWait
-    }
+    };
 
     AWS.Lambda.prototype.invoke = jest.fn().mockReturnValue({
-      promise: jest.fn().mockReturnValue(Promise.resolve({ data: "some data" }))
-    })
+      createReadStream: jest.fn().mockReturnValue(invokeResponse)
+    });
 
     const sut = new LambdaCloudService(context);
-    const response = await sut.invoke<Promise<any>>("aws-getCart", false, {});
+    const response = await sut.invoke<any>("aws-getCart", false, payload);
     expect(AWS.Lambda.prototype.invoke).toHaveBeenCalledWith(options);
-    expect(response.data).toEqual("some data");
-  })
+    expect(response).toEqual(invokeResponseBody);
+  });
+
+  it("should throw an error if the stream fails", async () => {
+    AWS.Lambda.prototype.invoke = jest.fn().mockReturnValue({
+      createReadStream: jest.fn().mockImplementation(() => {
+        const file = new Readable({
+          read() {}
+        });
+        setImmediate(() => file.emit("error", new Error("fail")));
+        return file;
+      })
+    });
+
+    const payload = {};
+    const sut = new LambdaCloudService(context);
+
+    await expect(sut.invoke<any>("aws-getCart", false, payload)).rejects.toThrow("fail");
+  });
 
   it("should return an error if no name is passed", async () => {
     const sut = new LambdaCloudService(context);
-    try {
-      await sut.invoke<Promise<any>>(null, false, {})
-    } catch (err) {
-      expect(err).toEqual(Error("Name is needed"));
-    }
-  })
+    await expect(sut.invoke<any>(null, false, {})).rejects.toMatch("Name is needed");
+  });
 
   it("should return an error if no region or arn is passed", async () => {
     const awsUpdateCartApi: AWSCloudServiceOptions = {
-      name: "aws-updateCart",
+      name: getCartAWSCloudService.name,
       arn: undefined,
       region: undefined,
     };
@@ -97,7 +121,7 @@ describe("LambdaCloudService", () => {
     container.bind(awsUpdateCartApi.name).toConstantValue(awsUpdateCartApi);
 
     const sut = new LambdaCloudService(context);
-    const invoke = async () => await sut.invoke<Promise<any>>("aws-updateCart", false, {});
-    await expect(invoke()).rejects.not.toBeNull();
-  })
-})
+    await expect(sut.invoke<any>("aws-getCart", false, {})).rejects.toMatch("Region and ARN are needed for Lambda calls");
+  });
+
+});


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Considering that the CloudService `invoke` call must be provider agnostic, we updated the AWS implementation to parse the **request** to comply the required format.
Additionally, we updated the **response** to return the data instead of the whole AWS response.

Closes N/A

<!--
Briefly describe the feature if no issue exists for this PR
-->

This issue was related to the CloudService `invoke` call where the **input and output** should be the same for every provider but when using AWS, the request and responses required some parsing before using it.

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

The AWS invocation request requires a payload that complies the `_Blob` type which can be `Buffer|Uint8Array|Blob|string`, meaning that we had to parse the payload received by parameter to string using `JSON.stringify()`.

Additionally, we found that according to the [AWS API-Gateway documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format) we should send the payload as `body`.

Moreover, we found that the AWS Lambda invoke call returns the `Payload` and the `Body` both as strings, meaning that we had to parse them to object to use it.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

| Unit tests working  |
| :----------------- |
| ![image](https://user-images.githubusercontent.com/20128985/66340235-207d9280-e91b-11e9-841a-34b45dd0964c.png) |

| Coverage before  | Coverage after  |
| :---------------- | :-------------- |
| ![image](https://user-images.githubusercontent.com/20128985/66345299-304ea400-e926-11e9-96d5-358eb8691193.png) | ![image](https://user-images.githubusercontent.com/20128985/66494179-a3265f00-ea8d-11e9-9cfa-0926115c8490.png) |

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.
       **Validate via `npm test`**
- [ ] Write documentation
- [x] Ensure there are no lint errors.
       **Validate via `npm run lint-updated`**
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [ ] Ensure introduced changes match Prettier formatting.
       **Validate via `npm run prettier-check-updated`**
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
