### PR TITLE
fix: Update AzureFunctionCloudService response

### DIFF
--- a/azure/src/services/azureFunctionCloudService.test.ts
+++ b/azure/src/services/azureFunctionCloudService.test.ts
@@ -37,8 +37,11 @@ describe("Azure Cloud Service should", () => {
       data: null,
       headers: {}
     };
-    axios.request = jest.fn().mockReturnValue(Promise.resolve());
-    await cloudService.invoke<Promise<any>>("azure-getCart", false);
+    axios.request = jest.fn().mockResolvedValue({
+      data: {}
+    });
+
+    await cloudService.invoke<any>("azure-getCart", false);
     expect(axios.request).toBeCalledWith(axiosRequestConfig);
   });
 
@@ -49,11 +52,15 @@ describe("Azure Cloud Service should", () => {
       data: null,
       headers: {}
     };
-    axios.request = jest.fn().mockReturnValue(Promise.resolve("Response"));
-    const response = await cloudService.invoke<Promise<any>>(
+    axios.request = jest.fn().mockResolvedValue({
+      data: "Response"
+    });
+
+    const response = await cloudService.invoke<any>(
       "azure-getCart",
       false
     );
+
     expect(axios.request).toBeCalledWith(axiosRequestConfig);
     expect(response).toEqual("Response");
   });
@@ -65,22 +72,19 @@ describe("Azure Cloud Service should", () => {
       data: null,
       headers: {}
     };
-    axios.request = jest.fn().mockReturnValue(Promise.resolve("Response"));
-    const response = await cloudService.invoke<Promise<any>>(
+    axios.request = jest.fn().mockResolvedValue({});
+
+    const response = await cloudService.invoke<any>(
       "azure-getCart",
       true
     );
+
     expect(axios.request).toBeCalledWith(axiosRequestConfig);
     expect(response).toBeUndefined();
   });
 
   it("return an error if no name is passed", async () => {
-    axios.request = jest.fn().mockReturnValue(Promise.resolve("Response"));
-    try {
-      await cloudService.invoke<Promise<any>>(null, true);
-    } catch (err) {
-      expect(err).toEqual(Error("Name is needed"));
-    }
+    await expect(cloudService.invoke<any>(null, true)).rejects.toMatch("Name is needed");
   });
 
   it("makes request with payload when defined", async () => {
@@ -88,12 +92,14 @@ describe("Azure Cloud Service should", () => {
     const payload = {
       a: 1
     };
+
     const axiosRequestConfig: AxiosRequestConfig = {
       url: "test-url",
       method: "GET",
       data: payload,
       headers: {}
     };
+
     const response = cloudService.invoke("azure-getCart", false, payload);
     expect(axios.request).toBeCalledWith(axiosRequestConfig);
     expect(response).not.toBeNull();
@@ -128,11 +134,8 @@ describe("Azure Cloud Service should", () => {
     };
     context.container = newResolver;
     axios.request = jest.fn().mockReturnValue(Promise.resolve("Response"));
+
     const sut = new AzureFunctionCloudService(context);
-    try {
-      await sut.invoke<Promise<any>>("azure-getCart", true);
-    } catch (err) {
-      expect(err).toEqual(Error("Missing Data"));
-    }
+    await expect(sut.invoke<any>("azure-getCart", true)).rejects.toMatch("Missing Data")
   });
 });

--- a/azure/src/services/azureFunctionCloudService.ts
+++ b/azure/src/services/azureFunctionCloudService.ts
@@ -46,19 +46,19 @@ export class AzureFunctionCloudService implements CloudService {
    */
   public async invoke<T>(
     name: string,
-    fireAndForget = false,
+    fireAndForget,
     payload: any = null,
     headers: StringParams = new StringParams()
   ) {
     if (!name || name.length === 0) {
-      throw Error("Name is needed");
+      return Promise.reject("Name is needed");
     }
 
     const context = this.containerResolver.resolve<AzureCloudServiceOptions>(
       name
     );
     if (!context.method || !context.http) {
-      throw Error("Missing Data");
+      return Promise.reject("Missing Data");
     }
 
     const axiosRequestConfig: AxiosRequestConfig = {
@@ -71,8 +71,10 @@ export class AzureFunctionCloudService implements CloudService {
     if (fireAndForget) {
       axios.request(axiosRequestConfig);
       return Promise.resolve(undefined);
-    } else {
-      return await axios.request<T>(axiosRequestConfig);
     }
+
+    const response = await axios.request<T>(axiosRequestConfig);
+
+    return Promise.resolve(response.data);
   }
 }


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Considering that the CloudService `invoke` call must be provider agnostic, we updated the Azure implementation to return the data instead of the whole `Axios` response.

Closes N/A

<!--
Briefly describe the feature if no issue exists for this PR
-->

This issue was related to the CloudService `invoke` call where the output should be the same for every provider but when using Azure, the response was an `Axios` response type.

## How did you implement it:

Instead of returning the whole `Axios` response, we wait for the request to finish and then we return the response data.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

| Unit tests working  |
| :----------------- |
| ![image](https://user-images.githubusercontent.com/20128985/66342010-ce3e7080-e91e-11e9-9d66-feddc54dfd5a.png)) |

| Coverage before  | Coverage after  |
| :---------------- | :-------------- |
| ![image](https://user-images.githubusercontent.com/20128985/66345964-83752680-e927-11e9-8e9d-e72f6593e384.png) | ![image](https://user-images.githubusercontent.com/20128985/66394332-3f2b6a00-e9ab-11e9-9b5b-2a624942c8f4.png) |

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.
       **Validate via `npm test`**
- [ ] Write documentation
- [x] Ensure there are no lint errors.
       **Validate via `npm run lint-updated`**
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [ ] Ensure introduced changes match Prettier formatting.
       **Validate via `npm run prettier-check-updated`**
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
