### PR TITLE
fix: modify the awsResponse to save the body after validation

### DIFF
--- a/aws/src/awsResponse.test.ts
+++ b/aws/src/awsResponse.test.ts
@@ -92,6 +92,16 @@ describe("test of response", () => {
     expect(response.status).toEqual(200);
   });
 
+  it("send() should not set the body if null", () => {
+    const context = new AwsContext([{}, {}]);
+    const response = new AwsResponse(context);
+
+    response.send();
+
+    expect(response.body).toBeUndefined();
+    expect(response.status).toEqual(200);
+  });
+
   it("send() should encode to base64 the body if buffer object", () => {
     const response = new AwsResponse(
       new AwsContext([{}, {}])

--- a/aws/src/awsResponse.ts
+++ b/aws/src/awsResponse.ts
@@ -46,16 +46,17 @@ export class AwsResponse implements CloudResponse {
    * @param contentType ContentType to apply it to response
    */
   public send(body: any = null, status: number = 200, contentType?: string): void {
-    const responseBody = typeof (body) !== "string"
-      ? JSON.stringify(body)
-      : body;
-
-    this.body = responseBody;
     this.status = status;
 
     if (!body) {
       return;
     }
+
+    const responseBody = typeof (body) !== "string"
+      ? JSON.stringify(body)
+      : body;
+
+    this.body = responseBody;
 
     const bodyType = body.constructor.name;
 


### PR DESCRIPTION
## What did you implement:

Closes #1288 (Azure devOps)

We have an issue with a funtion that is using the context.send function without parameters `context.send()` that is returning a `null` string in the body. This is because we are converting the body before validating that.

## How did you implement it:

We modified the order of the validation to validate the body before converting that to string using the stringify function.
Also, we added a new unit tests to validate the modification.

## How can we verify it:

Unit tests working:

![image](https://user-images.githubusercontent.com/28662111/66949612-37b03480-f02d-11e9-861d-989fa7aa73da.png)

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.
       **Validate via `npm test`**
- [ ] Write documentation
- [x] Ensure there are no lint errors.
       **Validate via `npm run lint-updated`**
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.
       **Validate via `npm run prettier-check-updated`**
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
