### PR TITLE
feat: Add function in azureFunctionCloudService to build dynamic URLs

### DIFF
--- a/azure/src/services/azureFunctionCloudService.test.ts
+++ b/azure/src/services/azureFunctionCloudService.test.ts
@@ -89,7 +89,7 @@ describe("Azure Cloud Service should", () => {
     await expect(cloudService.invoke<any>(null, true)).rejects.toMatch("Name is needed");
   });
 
-  it("makes request with payload when defined", async () => {
+  it("makes request with payload when defined with store_id", async () => {
     axios.request = jest.fn().mockReturnValue(Promise.resolve("Response"));
     const payload = {
       a: 1,
@@ -98,6 +98,24 @@ describe("Azure Cloud Service should", () => {
 
     const axiosRequestConfig: AxiosRequestConfig = {
       url: "http://test-url/id/123",
+      method: "GET",
+      data: payload,
+      headers: {}
+    };
+
+    const response = cloudService.invoke("azure-getCart", false, payload);
+    expect(axios.request).toBeCalledWith(axiosRequestConfig);
+    expect(response).not.toBeNull();
+  });
+
+  it("makes request with payload when defined without store_id", async () => {
+    axios.request = jest.fn().mockReturnValue(Promise.resolve("Response"));
+    const payload = {
+      a: 1
+    };
+
+    const axiosRequestConfig: AxiosRequestConfig = {
+      url: "http://test-url/",
       method: "GET",
       data: payload,
       headers: {}

--- a/azure/src/services/azureFunctionCloudService.ts
+++ b/azure/src/services/azureFunctionCloudService.ts
@@ -44,7 +44,7 @@ export class AzureFunctionCloudService implements CloudService {
    * @param pathParams Object with values to add to the URL
   */
   public requestURL(context: any, pathParams?: any) {
-    if(pathParams || pathParams.id) return context.http+"id/"+ pathParams.id;
+    if(pathParams && pathParams.id) return context.http+"id/"+ pathParams.id;
     else return context.http;
   }
   /**


### PR DESCRIPTION
## What did you implement:

Function that resolve pathParams object used by the CloudService invoke call to build dynamic URLs.

## How did you implement it:

Added a function in the azureFunctionCloudService to be used at the invoke call to build a new URL if it gets the required parameters. If not it returns the default http url.

Unit test had to be updated and it was also add a new test to get 100% of the coverage.

## How can we verify it:

__Unit tests working as expected__
![image](https://user-images.githubusercontent.com/34112271/67517556-37d9b100-f679-11e9-8941-184f7997072e.png)

__Coverage__
![image](https://user-images.githubusercontent.com/34112271/67510820-0a3a3b00-f66c-11e9-8962-67b13c195066.png)


## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.
       **Validate via `npm test`**
- [ ] Write documentation
- [x] Ensure there are no lint errors.
       **Validate via `npm run lint-updated`**
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.
       **Validate via `npm run prettier-check-updated`**
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
