### PR TITLE
feat: Add function in azureFunctionCloudService to build dynamic URLs

### DIFF
--- a/azure/src/services/azureFunctionCloudService.test.ts
+++ b/azure/src/services/azureFunctionCloudService.test.ts
@@ -17,13 +17,24 @@ describe("Azure Cloud Service should", () => {
   let container: CloudContainer;
   let cloudService: CloudService;
   let context;
+  let axiosRequestConfig: AxiosRequestConfig;
+
 
   beforeEach(() => {
     jest.clearAllMocks();
+
+    axiosRequestConfig = {
+      url: "test-url/",
+      method: "GET",
+      data: null,
+      headers: {}
+    };
+
     container = new CloudContainer();
     context = {
       container
     };
+
     cloudService = new AzureFunctionCloudService(context);
     container
       .bind(getCartAzureCloudService.name)
@@ -31,35 +42,22 @@ describe("Azure Cloud Service should", () => {
   });
 
   it("call axios.request with the configuration", async () => {
-    const axiosRequestConfig: AxiosRequestConfig = {
-      url: "test-url/",
-      method: "GET",
-      data: {},
-      headers: {}
-    };
     axios.request = jest.fn().mockResolvedValue({
       data: {}
     });
 
-    await cloudService.invoke<any>("azure-getCart", false, {  });
+    await cloudService.invoke<any>("azure-getCart", false);
     expect(axios.request).toBeCalledWith(axiosRequestConfig);
   });
 
   it("return data on fireAndWait", async () => {
-    const axiosRequestConfig: AxiosRequestConfig = {
-      url: "test-url/",
-      method: "GET",
-      data: {},
-      headers: {}
-    };
     axios.request = jest.fn().mockResolvedValue({
       data: "Response"
     });
 
     const response = await cloudService.invoke<any>(
       "azure-getCart",
-      false,
-      {}
+      false
     );
 
     expect(axios.request).toBeCalledWith(axiosRequestConfig);
@@ -67,18 +65,11 @@ describe("Azure Cloud Service should", () => {
   });
 
   it("return an empty response on fireAndForget", async () => {
-    const axiosRequestConfig: AxiosRequestConfig = {
-      url: "test-url/",
-      method: "GET",
-      data: {},
-      headers: {}
-    };
     axios.request = jest.fn().mockResolvedValue({});
 
     const response = await cloudService.invoke<any>(
       "azure-getCart",
       true,
-      {}
     );
 
     expect(axios.request).toBeCalledWith(axiosRequestConfig);
@@ -95,30 +86,53 @@ describe("Azure Cloud Service should", () => {
       a: 1
     };
 
-    const axiosRequestConfig: AxiosRequestConfig = {
-      url: "test-url/",
-      method: "GET",
-      data: payload,
-      headers: {}
+    const axiosRequestConfigPayload: AxiosRequestConfig = {
+      ...axiosRequestConfig,
+      data: payload
     };
 
     const response = cloudService.invoke("azure-getCart", false, payload);
-    expect(axios.request).toBeCalledWith(axiosRequestConfig);
+    expect(axios.request).toBeCalledWith(axiosRequestConfigPayload);
     expect(response).not.toBeNull();
+  });
+
+
+  it("makes request with url params when defined", async () => {
+    const getCartAzureCloudServiceWithUrl: AzureCloudServiceOptions = {
+      name: "azure-getCart-url",
+      http: "test-url/{store}/{id}",
+      method: "GET"
+    };
+    container
+      .bind(getCartAzureCloudServiceWithUrl.name)
+      .toConstantValue(getCartAzureCloudServiceWithUrl);
+
+    axios.request = jest.fn().mockReturnValue(Promise.resolve("Response"));;
+    const params = new StringParams({
+      id: 1,
+      item: "buu",
+      store: "fuu"
+    });
+
+    const axiosRequestConfigURL: AxiosRequestConfig = {
+      ...axiosRequestConfig,
+      url: "test-url/fuu/1",
+    };
+
+    await cloudService.invoke("azure-getCart-url", false, null, new StringParams(), params);
+    expect(axios.request).toBeCalledWith(axiosRequestConfigURL);
   });
 
   it("makes request with headers when defined", async () => {
     axios.request = jest.fn().mockReturnValue(Promise.resolve("Response"));
     const headers = new StringParams({ key: 123 });
 
-    const axiosRequestConfig: AxiosRequestConfig = {
-      url: "test-url/",
-      method: "GET",
-      data: {},
+    const axiosRequestConfigKey: AxiosRequestConfig = {
+      ...axiosRequestConfig,
       headers: headers.toJSON()
     };
-    const response = cloudService.invoke("azure-getCart", false, {  }, headers);
-    expect(axios.request).toBeCalledWith(axiosRequestConfig);
+    const response = cloudService.invoke("azure-getCart", false, null, headers);
+    expect(axios.request).toBeCalledWith(axiosRequestConfigKey);
     expect(response).not.toBeNull();
   });
 
@@ -145,31 +159,35 @@ describe("Azure Cloud Service should", () => {
 describe("buildURL", () => {
 
   it("should replace path params succesfully", async () => {
-    const http = "foo/bar/{baz}";
-    const payload = {
-      baz: 1
-    };
+    const http = "foo/bar/{baz}/{id}";
+    const params = new StringParams({
+      id: 8,
+      fuu: 32,
+      baz: "faa"
+    });
 
-    const sut = buildURL(http, payload);
+    const sut = buildURL(http, params);
 
-    await expect(sut).toEqual("foo/bar/1");
+    await expect(sut).toEqual("foo/bar/faa/8");
   });
 
   it("should return same http without changes", async () => {
     const http = "foo/bar/";
-    const payload = {
-      bar: 1
-    };
 
-    const sut = buildURL(http, payload);
+    const sut = buildURL(http, null);
 
     await expect(sut).toEqual("foo/bar/");
   });
 
-  it("should thorw an error on null pathParams", async () => {
-    const http = "foo/bar/{baz}";
-    const error = new Error("No parameters found");
+  it("should return same http without a data object in params", async () => {
+    const http = "foo/bar/";
+    const params = new StringParams({
+      data:{}
+    });
 
-    expect(()=>buildURL(http, null)).toThrow(error);
+    const sut = buildURL(http, params);
+
+    await expect(sut).toEqual("foo/bar/");
   });
+
 });

--- a/azure/src/services/azureFunctionCloudService.ts
+++ b/azure/src/services/azureFunctionCloudService.ts
@@ -21,15 +21,15 @@ export interface AzureCloudServiceOptions extends CloudServiceOptions {
   http: string;
 }
 
-export const buildURL = (http: string, pathParams: any): string => {
-  if (!pathParams) {
-    throw new Error("No parameters found");
-  }
-
+export const buildURL = (http: string, pathParams: StringParams): string => {
   let url = http;
 
-  Object.keys(pathParams).map(param => {
-    url = url.replace(`{${param}}`, pathParams[param]);
+  if (!pathParams) {
+    return url;
+  }
+
+  pathParams.forEach((value,key) => {
+    url = url.replace(`{${key}}`, value);
   });
 
   return url;
@@ -57,12 +57,15 @@ export class AzureFunctionCloudService implements CloudService {
    * @param name Name of function to invoke
    * @param fireAndForget Wait for response if false (default behavior)
    * @param payload Body of HTTP request
+   * @param headers Headers of the context
+   * @param params StringParams with values for URL
    */
   public async invoke<T>(
     name: string,
     fireAndForget,
     payload: any = null,
-    headers: StringParams = new StringParams()
+    headers: StringParams = new StringParams(),
+    params: StringParams = new StringParams()
   ) {
     if (!name || name.length === 0) {
       return Promise.reject("Name is needed");
@@ -75,7 +78,7 @@ export class AzureFunctionCloudService implements CloudService {
       return Promise.reject("Missing Data");
     }
     const axiosRequestConfig: AxiosRequestConfig = {
-      url: buildURL(context.http, payload),
+      url: buildURL(context.http, params),
       method: context.method,
       data: payload,
       headers: headers.toJSON()

--- a/azure/src/services/azureFunctionCloudService.ts
+++ b/azure/src/services/azureFunctionCloudService.ts
@@ -21,6 +21,20 @@ export interface AzureCloudServiceOptions extends CloudServiceOptions {
   http: string;
 }
 
+export const buildURL = (http: string, pathParams: any): string => {
+  if (!pathParams) {
+    throw new Error("No parameters found");
+  }
+
+  let url = http;
+
+  Object.keys(pathParams).map(param => {
+    url = url.replace(`{${param}}`, pathParams[param]);
+  });
+
+  return url;
+}
+
 /**
  * Implementation of Cloud Service for Azure Functions. Invokes HTTP Azure Functions
  */
@@ -60,9 +74,8 @@ export class AzureFunctionCloudService implements CloudService {
     if (!context.method || !context.http) {
       return Promise.reject("Missing Data");
     }
-
     const axiosRequestConfig: AxiosRequestConfig = {
-      url: context.http,
+      url: buildURL(context.http, payload),
       method: context.method,
       data: payload,
       headers: headers.toJSON()


### PR DESCRIPTION
## What did you implement:

Function that resolve pathParams object used by the CloudService invoke call to build dynamic URLs.

## How did you implement it:

Added a function in the azureFunctionCloudService to be used at the invoke call to build a new URL if it gets the required parameters. If not it returns the default http url.

Unit test had to be updated and it was also add new tests to get 100% of the coverage.

## How can we verify it:

__Unit tests working as expected__
![image](https://user-images.githubusercontent.com/34112271/67874133-47427980-fb13-11e9-98d0-25f9ee289b2e.png)

__Coverage__
![image](https://user-images.githubusercontent.com/34112271/67510820-0a3a3b00-f66c-11e9-8962-67b13c195066.png)


## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.
       **Validate via `npm test`**
- [ ] Write documentation
- [x] Ensure there are no lint errors.
       **Validate via `npm run lint-updated`**
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.
       **Validate via `npm run prettier-check-updated`**
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
