### PR TITLE
fix: Update the S3Storage to work with both node version 8.x and 10.x

### DIFF
--- a/aws/src/services/S3Storage.test.ts
+++ b/aws/src/services/S3Storage.test.ts
@@ -125,7 +125,7 @@ describe("aws storage when call write should", () => {
       Bucket: input.container,
       Key: input.path,
       Body: readableBody,
-      ContentLength: readableBody.readableLength
+      ContentLength: readableBody.readableLength || (readableBody as any)._readableState.length
     };
 
     await sut.write(input);
@@ -152,7 +152,7 @@ describe("aws storage when call write should", () => {
       Body: readableBody,
       CacheControl: "no-cache",
       ContentType: "application/json",
-      ContentLength: readableBody.readableLength
+      ContentLength: readableBody.readableLength || (readableBody as any)._readableState.length
     }
 
     await sut.write(inputBuffer);
@@ -179,7 +179,7 @@ describe("aws storage when call write should", () => {
       Bucket: inputStream.container,
       Key: inputStream.path,
       Body: readableBody,
-      ContentLength: readableBody.readableLength
+      ContentLength: readableBody.readableLength || (readableBody as any)._readableState.length
     };
 
     await sut.write(inputStream);

--- a/aws/src/services/S3Storage.ts
+++ b/aws/src/services/S3Storage.ts
@@ -53,7 +53,7 @@ export class S3Storage implements CloudStorage {
       Bucket: opts.container,
       Key: opts.path,
       Body: streamBody,
-      ContentLength: streamBody.readableLength
+      ContentLength: streamBody.readableLength || (streamBody as any)._readableState.length
     };
     const result = await this.s3.putObject(params).promise();
 


### PR DESCRIPTION
We modified the S3Storage file in order to read the readable object length both in node version 8.x and 10.x. We did that because when deployed an AWS handler that uploads a file in a bucket, the readable object in the 8.x node version doesn't have the readableLength property.

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

We updated the S3Storage to work with both node version 8.x and 10.x.

## How did you implement it:

We modified the S3Storage file in order to read the readable object length both in node version 8.x and 10.x. We did that because when deployed an AWS handler that uploads a file in a bucket, the readable object in the 8.x node version doesn't have the readableLength property.

## How can we verify it:

_Unit tests_

![image](https://user-images.githubusercontent.com/11664783/67881335-15cfab00-fb1f-11e9-817b-7d8be9e254d8.png)

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [X] Write tests and confirm existing functionality is not broken.
       **Validate via `npm test`**
- [X] Write documentation
- [X] Ensure there are no lint errors.
       **Validate via `npm run lint-updated`**
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [X] Ensure introduced changes match Prettier formatting.
       **Validate via `npm run prettier-check-updated`**
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [X] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
