### PR TITLE
fix: Resolves context.send regression

### DIFF
--- a/core/src/cloudContextBase.ts
+++ b/core/src/cloudContextBase.ts
@@ -27,11 +27,20 @@ export abstract class CloudContextBase implements CloudContext {
 
   public send(bodyOrResponse: any, status?: number, contentType?: string): void {
     if (this.res) {
-      const response: CloudResponseLike = {
-        body: bodyOrResponse ? (bodyOrResponse.body || bodyOrResponse) : null,
-        status: status || (status ? status : (bodyOrResponse ? bodyOrResponse.status : 200)) || 200,
-        headers: bodyOrResponse ? bodyOrResponse.headers || {} : {}
-      };
+      let response: CloudResponseLike;
+      if (arguments.length === 1) {
+        response = {
+          body: bodyOrResponse.body || bodyOrResponse || null,
+          status: bodyOrResponse.status && typeof (bodyOrResponse.status) === "number" ? bodyOrResponse.status : 200,
+          headers: bodyOrResponse.headers || {}
+        }
+      } else {
+        response = {
+          body: bodyOrResponse || null,
+          status: status || 200,
+          headers: {}
+        }
+      }
 
       if (contentType) {
         response.headers["Content-Type"] = contentType;

--- a/core/src/cloudContextBast.test.ts
+++ b/core/src/cloudContextBast.test.ts
@@ -107,4 +107,37 @@ describe("Cloud Context Base", () => {
       headers: headers
     });
   });
+
+  it("calls res.send() without status and with response like object with only body having a status property", () => {
+    const context = createTestContext();
+    const body = {
+      foo: "bar",
+      status: "OK"
+    };
+
+    // Call send without status
+    context.send(body);
+
+    expect(context.res.send).toBeCalledWith({
+      body,
+      status: 200,
+      headers: {}
+    });
+  });
+
+  it("calls res.send() with status 200 and with response like object with only body having a status property", () => {
+    const context = createTestContext();
+    const body = {
+      foo: "bar",
+      status: "OK"
+    };
+
+    context.send(body, 200);
+
+    expect(context.res.send).toBeCalledWith({
+      body,
+      status: 200,
+      headers: {}
+    });
+  });
 });


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:
Fixes a regression with `context.send(...)` where a `status` property on the `body` is misinterpreted as the status code for the response

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
Validate the status property is a number before assigned it as response status code

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
Run unit tests with `npm run test`

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.
       **Validate via `npm test`**
- [ ] Write documentation
- [x] Ensure there are no lint errors.
       **Validate via `npm run lint-updated`**
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [ ] Ensure introduced changes match Prettier formatting.
       **Validate via `npm run prettier-check-updated`**
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** NO
**_Is it a breaking change?:_** NO
