### PR TITLE
feat: Log the error when the flush method fails

### DIFF
--- a/core/src/middleware/telemetryMiddleware.test.ts
+++ b/core/src/middleware/telemetryMiddleware.test.ts
@@ -4,6 +4,7 @@ import { CloudContext } from "../cloudContext";
 import { TestContext } from "../testUtilities/testContext";
 import { App } from "../app";
 import { TelemetryService, TelemetryOptions } from "../services/telemetry";
+import { ConsoleLogger } from "../services/consoleLogger";
 import { TelemetryServiceMiddleware } from "./telemetryMiddleware";
 
 describe("TelemetryServiceMiddleware should", () => {
@@ -36,7 +37,7 @@ describe("TelemetryServiceMiddleware should", () => {
 
   const options: TelemetryOptions = {
     telemetryService: new TestTelemetryService(),
-    shouldFlush: true,
+    shouldFlush: true
   };
 
   let context: CloudContext;
@@ -100,6 +101,19 @@ describe("TelemetryServiceMiddleware should", () => {
 
     expect(collectSpy).toHaveBeenCalledWith(fooKey, data);
     expect(flushSpy).toHaveBeenCalled();
+  });
+
+  it("call logger error method when flush is rejected", async () => {
+    context.logger = new ConsoleLogger();
+    const errorSpy = jest.spyOn(ConsoleLogger.prototype, "error"),
+      error = new Error(),
+      next = jest.fn();
+
+    TestTelemetryService.prototype.flush = jest.fn().mockRejectedValue(error);
+
+    await TelemetryServiceMiddleware(options)(context, next);
+
+    expect(errorSpy).toHaveBeenCalled();
   });
 
   it("have values on the data array of the implementation", async () => {

--- a/core/src/middleware/telemetryMiddleware.ts
+++ b/core/src/middleware/telemetryMiddleware.ts
@@ -13,6 +13,8 @@ export const TelemetryServiceMiddleware = (options: TelemetryOptions): Middlewar
     const usedMemBeforeChain = GetUsedMemory();
 
     context.telemetry = options.telemetryService;
+    const { telemetry, logger } = context;
+
     await next();
 
     const finalCpuAverage = CpuAverage();
@@ -26,10 +28,10 @@ export const TelemetryServiceMiddleware = (options: TelemetryOptions): Middlewar
       memoryConsume
     };
 
-    context.telemetry.collect("stats", stats);
+    telemetry.collect("stats", stats);
 
     if (options.shouldFlush) {
-      context.telemetry.flush();
+      telemetry.flush().catch(err => logger.error(err));
     }
   };
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Log the error when the flush method fails.

## How did you implement it:

We modified the telemetry middlewares to log the error when the connection with Kinesis failed nd added a unit test for that new feature.

## How can we verify it:

_Unit tests_

![image](https://user-images.githubusercontent.com/11664783/68601324-e0ae4b80-0482-11ea-8bf9-43a4b5eddfe8.png)


## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [X] Write tests and confirm existing functionality is not broken.
       **Validate via `npm test`**
- [X] Write documentation
- [X] Ensure there are no lint errors.
       **Validate via `npm run lint-updated`**
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [X] Ensure introduced changes match Prettier formatting.
       **Validate via `npm run prettier-check-updated`**
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [X] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
