### PR TITLE
feat: Add InvokeRequest interface to replace invoke parameters

### DIFF
--- a/core/src/services/cloudService.ts
+++ b/core/src/services/cloudService.ts
@@ -1,6 +1,27 @@
 import { StringParams } from "../common/stringParams";
 
 /**
+ * Invoke Request options
+ * Implemented in order to have all the parameters needed for the invoke function in one object
+ */
+export interface InvokeRequest {
+  /**
+   * @param name Function name to invoke
+   * @param fireAndForget Wait for response if false (default behavior)
+   * @param payload HTTP request body
+   * @param headers Context headers
+   * @param pathParams StringParams with values for URL
+   * @param extraParams Extra parameters to invoke function
+   */
+  name: string;
+  fireAndForget: boolean;
+  payload: any;
+  headers?: StringParams;
+  pathParams?: StringParams;
+  extraParams?: any;
+}
+
+/**
  * Options for Cloud Service invocation
  */
 export interface CloudServiceOptions {
@@ -13,9 +34,7 @@ export interface CloudServiceOptions {
 export interface CloudService {
   /**
    * Invoke a deployed Serverless function
-   * @param name Name of function to forget
-   * @param fireAndForget Don't listen for response if true
-   * @param payload Payload to send in invocation
+   * @param invokeOptions parameters needed to call the invoke
    */
-  invoke<T>(name: string, fireAndForget: boolean, payload?: any, headers?: StringParams): Promise<T>;
+  invoke<T>(invokeOptions: InvokeRequest): Promise<T>;
 }


### PR DESCRIPTION
## What did you implement:

Implemented InvokeRequest interface in order to have all the parameters needed for the invoke function in one object

## How did you implement it:

Added an interface to the CloudService called InvokeRequest composed by all the parameters needed by the invoke call and changed the invoke signature to receive an InvokeRequest object.

## How can we verify it:

### Core: 

__Unit tests working as expected__
![image](https://user-images.githubusercontent.com/34112271/68885557-2756ac80-06f4-11ea-9598-4c6cccd482c2.png)

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.
       **Validate via `npm test`**
- [ ] Write documentation
- [x] Ensure there are no lint errors.
       **Validate via `npm run lint-updated`**
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.
       **Validate via `npm run prettier-check-updated`**
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
