### PR TITLE
feat: Add invokeRequest to the azureFunctionCloudService

### DIFF
--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -1215,9 +1215,9 @@
       }
     },
     "@multicloud/sls-core": {
-      "version": "0.1.1-23",
-      "resolved": "https://registry.npmjs.org/@multicloud/sls-core/-/sls-core-0.1.1-23.tgz",
-      "integrity": "sha512-RDhG+08EjHjsxk2LdRg1ylyvf1csQaeuCvasuKN7fHJ+DW6+rc88BRyNKZV7HWYXMuexcrmrtiNczfBAyP7WTw==",
+      "version": "0.1.1-29",
+      "resolved": "https://registry.npmjs.org/@multicloud/sls-core/-/sls-core-0.1.1-29.tgz",
+      "integrity": "sha512-PXtvQwk1VecxtrFBiIrKM5txCUCoNYfbkAEnOzfJxlX4k+82qxmhoed9LgSymvXRXA0+eDXXEDLJBK0EZbxH8g==",
       "requires": {
         "inversify": "5.0.1",
         "reflect-metadata": "0.1.13"
@@ -2959,8 +2959,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2981,14 +2980,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3003,20 +3000,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3133,8 +3127,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3146,7 +3139,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3161,7 +3153,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3169,14 +3160,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3195,7 +3184,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3276,8 +3264,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3289,7 +3276,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3375,8 +3361,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3412,7 +3397,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3432,7 +3416,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3476,14 +3459,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/azure/package.json
+++ b/azure/package.json
@@ -34,7 +34,7 @@
   "license": "MIT",
   "dependencies": {
     "@azure/storage-blob": "10.3.0",
-    "@multicloud/sls-core": "^0.1.1-23",
+    "@multicloud/sls-core": "0.1.1-29",
     "inversify": "5.0.1",
     "reflect-metadata": "0.1.13",
     "streamifier": "0.1.1"

--- a/azure/src/azureContext.test.ts
+++ b/azure/src/azureContext.test.ts
@@ -100,7 +100,7 @@ describe("Azure context", () => {
       status: 400
     };
 
-    context.send(response);
+    context.send(response.body, response.status);
 
     expect(context.res.send).toBeCalledWith({
       body: response.body,

--- a/azure/src/services/azureFunctionCloudService.test.ts
+++ b/azure/src/services/azureFunctionCloudService.test.ts
@@ -3,6 +3,7 @@ import {
   ContainerResolver,
   CloudContainer,
   CloudService,
+  InvokeRequest,
   StringParams
 } from "@multicloud/sls-core";
 import { AzureFunctionCloudService, AzureCloudServiceOptions, buildURL } from ".";
@@ -46,7 +47,13 @@ describe("Azure Cloud Service should", () => {
       data: {}
     });
 
-    await cloudService.invoke<any>("azure-getCart", false);
+    const params: InvokeRequest = {
+      name: "azure-getCart",
+      fireAndForget: false,
+      payload: null,
+      headers: new StringParams()
+    };
+    await cloudService.invoke<any>(params);
     expect(axios.request).toBeCalledWith(axiosRequestConfig);
   });
 
@@ -55,10 +62,13 @@ describe("Azure Cloud Service should", () => {
       data: "Response"
     });
 
-    const response = await cloudService.invoke<any>(
-      "azure-getCart",
-      false
-    );
+    const params: InvokeRequest = {
+      name: "azure-getCart",
+      fireAndForget: false,
+      payload: null,
+      headers: new StringParams()
+    };
+    const response = await cloudService.invoke(params);
 
     expect(axios.request).toBeCalledWith(axiosRequestConfig);
     expect(response).toEqual("Response");
@@ -67,17 +77,26 @@ describe("Azure Cloud Service should", () => {
   it("return an empty response on fireAndForget", async () => {
     axios.request = jest.fn().mockResolvedValue({});
 
-    const response = await cloudService.invoke<any>(
-      "azure-getCart",
-      true,
-    );
+    const params: InvokeRequest = {
+      name: "azure-getCart",
+      fireAndForget: true,
+      payload: null,
+      headers: new StringParams()
+    };
+    const response = await cloudService.invoke(params);
 
     expect(axios.request).toBeCalledWith(axiosRequestConfig);
     expect(response).toBeUndefined();
   });
 
   it("return an error if no name is passed", async () => {
-    await expect(cloudService.invoke<any>(null, true)).rejects.toMatch("Name is needed");
+    const params: InvokeRequest = {
+      name: null,
+      fireAndForget: false,
+      payload: null,
+      headers: new StringParams()
+    };
+    await expect(cloudService.invoke(params)).rejects.toMatch("Name is needed");
   });
 
   it("makes request with payload when defined", async () => {
@@ -91,7 +110,13 @@ describe("Azure Cloud Service should", () => {
       data: payload
     };
 
-    const response = cloudService.invoke("azure-getCart", false, payload);
+    const params: InvokeRequest = {
+      name: "azure-getCart",
+      fireAndForget: false,
+      payload: payload,
+      headers: new StringParams()
+    };
+    const response = await cloudService.invoke(params);
     expect(axios.request).toBeCalledWith(axiosRequestConfigPayload);
     expect(response).not.toBeNull();
   });
@@ -108,7 +133,7 @@ describe("Azure Cloud Service should", () => {
       .toConstantValue(getCartAzureCloudServiceWithUrl);
 
     axios.request = jest.fn().mockReturnValue(Promise.resolve("Response"));;
-    const params = new StringParams({
+    const pathParams = new StringParams({
       id: 1,
       item: "buu",
       store: "fuu"
@@ -119,7 +144,14 @@ describe("Azure Cloud Service should", () => {
       url: "test-url/fuu/1",
     };
 
-    await cloudService.invoke("azure-getCart-url", false, null, new StringParams(), params);
+    const params: InvokeRequest = {
+      name: "azure-getCart-url",
+      fireAndForget: false,
+      payload: null,
+      headers: new StringParams(),
+      pathParams: pathParams
+    };
+    await cloudService.invoke(params);
     expect(axios.request).toBeCalledWith(axiosRequestConfigURL);
   });
 
@@ -131,7 +163,14 @@ describe("Azure Cloud Service should", () => {
       ...axiosRequestConfig,
       headers: headers.toJSON()
     };
-    const response = cloudService.invoke("azure-getCart", false, null, headers);
+
+    const params: InvokeRequest = {
+      name: "azure-getCart",
+      fireAndForget: false,
+      payload: null,
+      headers: headers
+    };
+    const response = await cloudService.invoke(params);
     expect(axios.request).toBeCalledWith(axiosRequestConfigKey);
     expect(response).not.toBeNull();
   });
@@ -152,7 +191,13 @@ describe("Azure Cloud Service should", () => {
     axios.request = jest.fn().mockReturnValue(Promise.resolve("Response"));
 
     const sut = new AzureFunctionCloudService(context);
-    await expect(sut.invoke<any>("azure-getCart", true)).rejects.toMatch("Missing Data")
+    const params: InvokeRequest = {
+      name: "azure-getCart",
+      fireAndForget: true,
+      payload: null,
+      headers: new StringParams()
+    };
+    await expect(sut.invoke(params)).rejects.toMatch("Missing Data")
   });
 });
 

--- a/azure/src/services/azureFunctionCloudService.ts
+++ b/azure/src/services/azureFunctionCloudService.ts
@@ -3,6 +3,7 @@ import {
   ContainerResolver,
   CloudServiceOptions,
   CloudContext,
+  InvokeRequest,
   StringParams
 } from "@multicloud/sls-core";
 import axios, { AxiosRequestConfig } from "axios";
@@ -53,20 +54,10 @@ export class AzureFunctionCloudService implements CloudService {
   public containerResolver: ContainerResolver;
 
   /**
-   *
-   * @param name Name of function to invoke
-   * @param fireAndForget Wait for response if false (default behavior)
-   * @param payload Body of HTTP request
-   * @param headers Headers of the context
-   * @param params StringParams with values for URL
+   * @param invokeOptions invoke interface with parameters needed
    */
-  public async invoke<T>(
-    name: string,
-    fireAndForget,
-    payload: any = null,
-    headers: StringParams = new StringParams(),
-    params: StringParams = new StringParams()
-  ) {
+  public async invoke<T>(invokeOptions: InvokeRequest) {
+    const { name, fireAndForget, payload, headers, pathParams } = invokeOptions;
     if (!name || name.length === 0) {
       return Promise.reject("Name is needed");
     }
@@ -78,7 +69,7 @@ export class AzureFunctionCloudService implements CloudService {
       return Promise.reject("Missing Data");
     }
     const axiosRequestConfig: AxiosRequestConfig = {
-      url: buildURL(context.http, params),
+      url: buildURL(context.http, pathParams),
       method: context.method,
       data: payload,
       headers: headers.toJSON()


### PR DESCRIPTION
## What did you implement:

Implemented InvokeRequest interface in the invoke call in order to have all the parameters needed for the invoke function in one object.

Expected to fail azure deploy until [core PR](https://github.com/serverless/multicloud/pull/46) is merged

## How did you implement it:

Updated the azureFunctionCloudService to use this interface in the invoke call and the corresponding unit test.

## How can we verify it:

__Unit tests working as expected__
![image](https://user-images.githubusercontent.com/34112271/68885163-60425180-06f3-11ea-8cec-1b2032ec29df.png)


__Coverage__
![image](https://user-images.githubusercontent.com/34112271/68885427-e8c0f200-06f3-11ea-9d4e-9a89e1e5d726.png)

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.
       **Validate via `npm test`**
- [ ] Write documentation
- [x] Ensure there are no lint errors.
       **Validate via `npm run lint-updated`**
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.
       **Validate via `npm run prettier-check-updated`**
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** YES
