### PR TITLE
feat: Add invokeRequest to the lambdaService

### DIFF
--- a/aws/package-lock.json
+++ b/aws/package-lock.json
@@ -1215,9 +1215,9 @@
       }
     },
     "@multicloud/sls-core": {
-      "version": "0.1.1-23",
-      "resolved": "https://registry.npmjs.org/@multicloud/sls-core/-/sls-core-0.1.1-23.tgz",
-      "integrity": "sha512-RDhG+08EjHjsxk2LdRg1ylyvf1csQaeuCvasuKN7fHJ+DW6+rc88BRyNKZV7HWYXMuexcrmrtiNczfBAyP7WTw==",
+      "version": "0.1.1-29",
+      "resolved": "https://registry.npmjs.org/@multicloud/sls-core/-/sls-core-0.1.1-29.tgz",
+      "integrity": "sha512-PXtvQwk1VecxtrFBiIrKM5txCUCoNYfbkAEnOzfJxlX4k+82qxmhoed9LgSymvXRXA0+eDXXEDLJBK0EZbxH8g==",
       "requires": {
         "inversify": "5.0.1",
         "reflect-metadata": "0.1.13"
@@ -2919,8 +2919,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2941,14 +2940,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2963,20 +2960,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3093,8 +3087,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3106,7 +3099,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3121,7 +3113,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3129,14 +3120,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3155,7 +3144,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3236,8 +3224,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3249,7 +3236,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3335,8 +3321,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3372,7 +3357,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3392,7 +3376,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3436,14 +3419,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/aws/package.json
+++ b/aws/package.json
@@ -33,7 +33,7 @@
   "author": "Microsoft Corporation, 7-Eleven & Serverless Inc",
   "license": "MIT",
   "dependencies": {
-    "@multicloud/sls-core": "^0.1.1-23",
+    "@multicloud/sls-core": "0.1.1-29",
     "aws-sdk": "2.476.0",
     "inversify": "5.0.1",
     "reflect-metadata": "0.1.13"

--- a/aws/src/services/lambdaCloudService.test.ts
+++ b/aws/src/services/lambdaCloudService.test.ts
@@ -4,7 +4,8 @@ import {
   CloudContainer,
   CloudContext,
   CloudContextBuilder,
-  convertToStream
+  convertToStream,
+  InvokeRequest
 } from "@multicloud/sls-core";
 import {
   AWSCloudServiceOptions,
@@ -49,7 +50,12 @@ describe("LambdaCloudService", () => {
 
   it("should create a Lambda instance", async () => {
     const sut = new LambdaCloudService(context);
-    await sut.invoke<any>("aws-getCart", null, {});
+    const params: InvokeRequest = {
+      name: "aws-getCart",
+      fireAndForget: null,
+      payload: {},
+    };
+    await sut.invoke<any>(params);
     expect(AWS.Lambda).toHaveBeenCalled();
   });
 
@@ -62,7 +68,12 @@ describe("LambdaCloudService", () => {
     };
 
     const sut = new LambdaCloudService(context);
-    await sut.invoke<any>("aws-getCart", null, payload);
+    const params: InvokeRequest = {
+      name: "aws-getCart",
+      fireAndForget: null,
+      payload: payload,
+    };
+    await sut.invoke<any>(params);
     expect(AWS.Lambda.prototype.invoke).toHaveBeenCalledWith(options);
   });
 
@@ -75,7 +86,12 @@ describe("LambdaCloudService", () => {
     };
 
     const sut = new LambdaCloudService(context);
-    const response = await sut.invoke<any>("aws-getCart", true, payload);
+    const params: InvokeRequest = {
+      name: "aws-getCart",
+      fireAndForget: true,
+      payload: payload,
+    };
+    const response = await sut.invoke<any>(params);
     expect(AWS.Lambda.prototype.invoke).toHaveBeenCalledWith(options);
     expect(response).toBeUndefined();
   });
@@ -93,7 +109,12 @@ describe("LambdaCloudService", () => {
     });
 
     const sut = new LambdaCloudService(context);
-    const response = await sut.invoke<any>("aws-getCart", false, payload);
+    const params: InvokeRequest = {
+      name: "aws-getCart",
+      fireAndForget: false,
+      payload: payload,
+    };
+    const response = await sut.invoke<any>(params);
     expect(AWS.Lambda.prototype.invoke).toHaveBeenCalledWith(options);
     expect(response).toEqual(invokeResponseBody);
   });
@@ -111,13 +132,24 @@ describe("LambdaCloudService", () => {
 
     const payload = {};
     const sut = new LambdaCloudService(context);
+    const params: InvokeRequest = {
+      name: "aws-getCart",
+      fireAndForget: false,
+      payload: payload,
+    };
 
-    await expect(sut.invoke<any>("aws-getCart", false, payload)).rejects.toThrow("fail");
+    await expect(sut.invoke<any>(params)).rejects.toThrow("fail");
   });
 
   it("should return an error if no name is passed", async () => {
     const sut = new LambdaCloudService(context);
-    await expect(sut.invoke<any>(null, false, {})).rejects.toMatch("Name is needed");
+    const params: InvokeRequest = {
+      name: null,
+      fireAndForget: false,
+      payload: {},
+    };
+
+    await expect(sut.invoke<any>(params)).rejects.toMatch("Name is needed");
   });
 
   it("should return an error if no region or arn is passed", async () => {
@@ -130,7 +162,13 @@ describe("LambdaCloudService", () => {
     container.bind(awsUpdateCartApi.name).toConstantValue(awsUpdateCartApi);
 
     const sut = new LambdaCloudService(context);
-    await expect(sut.invoke<any>("aws-getCart", false, {})).rejects.toMatch("Region and ARN are needed for Lambda calls");
+    const params: InvokeRequest = {
+      name: "aws-getCart",
+      fireAndForget: false,
+      payload: {},
+    };
+
+    await expect(sut.invoke<any>(params)).rejects.toMatch("Region and ARN are needed for Lambda calls");
   });
 
 });

--- a/aws/src/services/lambdaCloudService.ts
+++ b/aws/src/services/lambdaCloudService.ts
@@ -1,6 +1,5 @@
 import AWS from "aws-sdk";
-import { CloudService, ContainerResolver, CloudServiceOptions, CloudContext } from "@multicloud/sls-core";
-import { ComponentType } from "@multicloud/sls-core";
+import { CloudService, ContainerResolver, CloudServiceOptions, CloudContext, ComponentType, InvokeRequest } from "@multicloud/sls-core";
 import { injectable, inject } from "inversify";
 
 /**
@@ -80,11 +79,11 @@ export class LambdaCloudService implements CloudService {
 
   /**
    *
-   * @param name Name of Lambda function to invoke
-   * @param fireAndForget Wait for response if false (default behavior)
-   * @param payload Body of HTTP request
+   * @param invokeOptions invoke interface with parameters needed
    */
-  public async invoke<T>(name: string, fireAndForget, payload: any): Promise<T> {
+  public async invoke<T>(invokeOptions: InvokeRequest): Promise<T> {
+    const { name, fireAndForget, payload } = invokeOptions;
+
     if (!name || name.length === 0) {
       return Promise.reject("Name is needed");
 	  }


### PR DESCRIPTION
## What did you implement:

Implemented InvokeRequest interface in the invoke call in order to have all the parameters needed for the invoke function in one object.

Expected to fail AWS deploy until [core PR](https://github.com/serverless/multicloud/pull/46) is merged

## How did you implement it:

Updated the lambdaCloudService to use this interface in the invoke call and the corresponding unit test.

## How can we verify it:

__Unit tests working as expected__

![image](https://user-images.githubusercontent.com/34112271/68965748-4ff5a980-07bb-11ea-89b0-45d9f77185d5.png)

__Coverage__

![image](https://user-images.githubusercontent.com/34112271/68965836-7f0c1b00-07bb-11ea-9569-278058474c24.png)

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.
       **Validate via `npm test`**
- [ ] Write documentation
- [x] Ensure there are no lint errors.
       **Validate via `npm run lint-updated`**
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.
       **Validate via `npm run prettier-check-updated`**
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** YES
