### PR TITLE
feat: modify exception middleware to support errors as object

### DIFF
--- a/core/src/middleware/exceptionMiddleware.ts
+++ b/core/src/middleware/exceptionMiddleware.ts
@@ -21,7 +21,7 @@ export const ExceptionMiddleware = (options: ExceptionOptions): Middleware =>
 
       const result = {
         requestId: context.id,
-        message: err.toString(),
+        message: typeof err === "string" ? err : (err instanceof Error ? err.toString() : JSON.stringify(err)),
         timestamp: new Date()
       };
 


### PR DESCRIPTION
## What did you implement:

Closes #1612

We modified the Exception middleware in order to support error as object because we are getting the following error from the 7-11 endpoints. 

```
{
    "requestId": "offline_awsRequestId_856122821771298",
    "message": "[object Object]",
    "timestamp": "2019-11-21T18:29:01.130Z"
}
```

## How did you implement it:

We added a validation in the middleware to use JSON.Stringify for object or toString() for Error.

## How can we verify it:

_Unit tests working_

![image](https://user-images.githubusercontent.com/28662111/69371235-32728500-0c7e-11ea-845f-2304641cb02b.png)


## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.
       **Validate via `npm test`**
- [ ] Write documentation
- [x] Ensure there are no lint errors.
       **Validate via `npm run lint-updated`**
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Ensure introduced changes match Prettier formatting.
       **Validate via `npm run prettier-check-updated`**
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
