### PR TITLE
WIP: feat: Update the sls-azure library to support the deprecated method

### DIFF
--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -1215,9 +1215,9 @@
       }
     },
     "@multicloud/sls-core": {
-      "version": "0.1.1-29",
-      "resolved": "https://registry.npmjs.org/@multicloud/sls-core/-/sls-core-0.1.1-29.tgz",
-      "integrity": "sha512-PXtvQwk1VecxtrFBiIrKM5txCUCoNYfbkAEnOzfJxlX4k+82qxmhoed9LgSymvXRXA0+eDXXEDLJBK0EZbxH8g==",
+      "version": "0.1.1-30",
+      "resolved": "https://registry.npmjs.org/@multicloud/sls-core/-/sls-core-0.1.1-30.tgz",
+      "integrity": "sha512-PCfuwOidFp2YNaNYfKArGVr0iF5K4ChMKfHF93tH1B6IIMm11R6VasgfahEvlAuzaN9tpH23Uyb//pJPO8fgoQ==",
       "requires": {
         "inversify": "5.0.1",
         "reflect-metadata": "0.1.13"

--- a/azure/package.json
+++ b/azure/package.json
@@ -34,7 +34,7 @@
   "license": "MIT",
   "dependencies": {
     "@azure/storage-blob": "10.3.0",
-    "@multicloud/sls-core": "0.1.1-29",
+    "@multicloud/sls-core": "^0.1.1-30",
     "inversify": "5.0.1",
     "reflect-metadata": "0.1.13",
     "streamifier": "0.1.1"

--- a/azure/src/services/azureFunctionCloudService.test.ts
+++ b/azure/src/services/azureFunctionCloudService.test.ts
@@ -8,11 +8,7 @@ import {
 } from "@multicloud/sls-core";
 import { AzureFunctionCloudService, AzureCloudServiceOptions, buildURL } from ".";
 
-const getCartAzureCloudService: AzureCloudServiceOptions = {
-  name: "azure-getCart",
-  http: "test-url/",
-  method: "GET"
-};
+let getCartAzureCloudService: AzureCloudServiceOptions;
 
 describe("Azure Cloud Service should", () => {
   let container: CloudContainer;
@@ -21,14 +17,20 @@ describe("Azure Cloud Service should", () => {
   let axiosRequestConfig: AxiosRequestConfig;
 
 
-  beforeEach(() => {
+  beforeEach(async () => {
     jest.clearAllMocks();
 
     axiosRequestConfig = {
       url: "test-url/",
-      method: "GET",
+      method: "POST",
       data: null,
       headers: {}
+    };
+
+    getCartAzureCloudService = {
+      name: "azure-getCart",
+      http: "test-url/",
+      method: "POST"
     };
 
     container = new CloudContainer();
@@ -54,6 +56,25 @@ describe("Azure Cloud Service should", () => {
       headers: new StringParams()
     };
     await cloudService.invoke<any>(params);
+    expect(axios.request).toBeCalledWith(axiosRequestConfig);
+  });
+
+  it("call axios.request with the configuration without the data parameter", async () => {
+    axios.request = jest.fn().mockResolvedValue({
+      data: {}
+    });
+    const params: InvokeRequest = {
+      name: "azure-getCart",
+      fireAndForget: false,
+      payload: null,
+      headers: new StringParams()
+    };
+    getCartAzureCloudService.method = "GET";
+    axiosRequestConfig.method = "GET";
+    delete axiosRequestConfig.data;
+
+    await cloudService.invoke<any>(params);
+    
     expect(axios.request).toBeCalledWith(axiosRequestConfig);
   });
 
@@ -126,7 +147,7 @@ describe("Azure Cloud Service should", () => {
     const getCartAzureCloudServiceWithUrl: AzureCloudServiceOptions = {
       name: "azure-getCart-url",
       http: "test-url/{store}/{id}",
-      method: "GET"
+      method: "POST"
     };
     container
       .bind(getCartAzureCloudServiceWithUrl.name)


### PR DESCRIPTION
## What did you implement:

Update the sls-azure library to support the deprecated method

## How did you implement it:

We added the old invoke method to the AzureFunctionCloudService as a deprecated method to don't modify the CloudService consumers. We overloaded the invoke method and took the corresponding action in the implementation method if is called the deprecated or the new method. This new feature only works when the sls-core library is updated with the CloudService latest changes.

## How can we verify it:

_Unit tests_
![image](https://user-images.githubusercontent.com/11664783/69869222-fc8b5d00-128a-11ea-839b-7ffd6022287b.png)

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Update the sls-core library with the CloudService latest version.
- [x] Write tests and confirm existing functionality is not broken.
       **Validate via `npm test`**
- [ ] Write documentation
- [X] Ensure there are no lint errors.
       **Validate via `npm run lint-updated`**
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [X] Ensure introduced changes match Prettier formatting.
       **Validate via `npm run prettier-check-updated`**
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [X] Make sure code coverage hasn't dropped
- [X] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
