### PR TITLE
feat: Update the sls-aws library to support the deprecated method

### DIFF
--- a/aws/package-lock.json
+++ b/aws/package-lock.json
@@ -1215,9 +1215,9 @@
       }
     },
     "@multicloud/sls-core": {
-      "version": "0.1.1-29",
-      "resolved": "https://registry.npmjs.org/@multicloud/sls-core/-/sls-core-0.1.1-29.tgz",
-      "integrity": "sha512-PXtvQwk1VecxtrFBiIrKM5txCUCoNYfbkAEnOzfJxlX4k+82qxmhoed9LgSymvXRXA0+eDXXEDLJBK0EZbxH8g==",
+      "version": "0.1.1-30",
+      "resolved": "https://registry.npmjs.org/@multicloud/sls-core/-/sls-core-0.1.1-30.tgz",
+      "integrity": "sha512-PCfuwOidFp2YNaNYfKArGVr0iF5K4ChMKfHF93tH1B6IIMm11R6VasgfahEvlAuzaN9tpH23Uyb//pJPO8fgoQ==",
       "requires": {
         "inversify": "5.0.1",
         "reflect-metadata": "0.1.13"

--- a/aws/package.json
+++ b/aws/package.json
@@ -33,7 +33,7 @@
   "author": "Microsoft Corporation, 7-Eleven & Serverless Inc",
   "license": "MIT",
   "dependencies": {
-    "@multicloud/sls-core": "0.1.1-29",
+    "@multicloud/sls-core": "0.1.1-30",
     "aws-sdk": "2.476.0",
     "inversify": "5.0.1",
     "reflect-metadata": "0.1.13"


### PR DESCRIPTION
## What did you implement:

Update the sls-aws library to support the deprecated method

## How did you implement it:

We added the old invoke method to the LambdaCloudService as a deprecated method to don't modify the CloudService consumers. We overloaded the invoke method and took the corresponding action in the implementation method if is called the deprecated or the new method. This new feature only works when the sls-core library is updated with the CloudService latest changes.

## How can we verify it:

_Unit tests_
![image](https://user-images.githubusercontent.com/11664783/69754509-d8b60300-1134-11ea-9e3d-8a439e56dd0c.png)

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [x] Update the sls-core library with the CloudService latest version.
- [ ] Write tests and confirm existing functionality is not broken.
       **Validate via `npm test`**
- [ ] Write documentation
- [X] Ensure there are no lint errors.
       **Validate via `npm run lint-updated`**
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [X] Ensure introduced changes match Prettier formatting.
       **Validate via `npm run prettier-check-updated`**
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [X] Make sure code coverage hasn't dropped
- [X] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
