### PR TITLE
fix: Remove the caret symbol from the sls-core version

### DIFF
--- a/azure/package.json
+++ b/azure/package.json
@@ -34,7 +34,7 @@
   "license": "MIT",
   "dependencies": {
     "@azure/storage-blob": "10.3.0",
-    "@multicloud/sls-core": "^0.1.1-30",
+    "@multicloud/sls-core": "0.1.1-30",
     "inversify": "5.0.1",
     "reflect-metadata": "0.1.13",
     "streamifier": "0.1.1"


### PR DESCRIPTION
## What did you implement:

Remove the caret symbol from the sls-core version

## How did you implement it:

We updated the @multicloud/sls-core version in order to remove the caret symbol from it.

## How can we verify it:

_Unit tests_
![image](https://user-images.githubusercontent.com/11664783/69878104-b17d4400-12a2-11ea-8151-a80fc9b8ad03.png)

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [ ] Write tests and confirm existing functionality is not broken.
       **Validate via `npm test`**
- [ ] Write documentation
- [X] Ensure there are no lint errors.
       **Validate via `npm run lint-updated`**
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [X] Ensure introduced changes match Prettier formatting.
       **Validate via `npm run prettier-check-updated`**
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [X] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
