### PR TITLE
feat: We implemented the CloudRequest's path property in the AzureRequest class

### DIFF
--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -1215,9 +1215,9 @@
       }
     },
     "@multicloud/sls-core": {
-      "version": "0.1.1-30",
-      "resolved": "https://registry.npmjs.org/@multicloud/sls-core/-/sls-core-0.1.1-30.tgz",
-      "integrity": "sha512-PCfuwOidFp2YNaNYfKArGVr0iF5K4ChMKfHF93tH1B6IIMm11R6VasgfahEvlAuzaN9tpH23Uyb//pJPO8fgoQ==",
+      "version": "0.1.1-31",
+      "resolved": "https://registry.npmjs.org/@multicloud/sls-core/-/sls-core-0.1.1-31.tgz",
+      "integrity": "sha512-bnlhF0cDN1d9albMJF8G0X7c1qgPGXcD6Kh85vOv2BDO+hTqsW8/SReLLj0LIYr+omvHhCUG0IL6lLlGj6VtpA==",
       "requires": {
         "inversify": "5.0.1",
         "reflect-metadata": "0.1.13"

--- a/azure/package.json
+++ b/azure/package.json
@@ -34,7 +34,7 @@
   "license": "MIT",
   "dependencies": {
     "@azure/storage-blob": "10.3.0",
-    "@multicloud/sls-core": "0.1.1-30",
+    "@multicloud/sls-core": "0.1.1-31",
     "inversify": "5.0.1",
     "reflect-metadata": "0.1.13",
     "streamifier": "0.1.1"

--- a/azure/src/azureRequest.test.ts
+++ b/azure/src/azureRequest.test.ts
@@ -110,6 +110,52 @@ describe("test of request", () => {
     expect(azureContext.req.query).toEqual(expectedQueryParams);
   });
 
+  it("should passthrough expected path value without modifications", () => {
+    let expectedPath = "/path1/path2";
+    let url = `http://test.com${expectedPath}`;
+    const runtimeArgs = [
+      {
+        ...runtimeContext,
+        req: {
+          event: {
+            url: url
+          }
+        },
+      }
+    ];
+
+    let azureContext = createAzureContext(runtimeArgs);
+    expect(azureContext.req.path).toEqual(expectedPath);
+
+    runtimeArgs[0].req.event.url = url.replace(expectedPath, "");
+    azureContext = createAzureContext(runtimeArgs);
+    expect(azureContext.req.path).toEqual("/");
+  });
+
+  it("should passthrough an empty path value cause of an invalid/unexisting url", () => {
+    const expectedPath = "";
+    const runtimeArgs = [
+      {
+        ...runtimeContext,
+        req: {
+          event: {
+            url: "invalid url"
+          }
+        },
+      }
+    ];
+    let azureContext = createAzureContext(runtimeArgs);
+    expect(azureContext.req.path).toEqual(expectedPath);
+
+    delete runtimeArgs[0].req.event.url;
+    azureContext = createAzureContext(runtimeArgs);
+    expect(azureContext.req.path).toEqual(expectedPath);
+
+    delete runtimeArgs[0].req.event;
+    azureContext = createAzureContext(runtimeArgs);
+    expect(azureContext.req.path).toEqual(expectedPath);
+  });
+
   it("should check if context content are empty objects", () => {
     const azureContext = createAzureContext([runtimeContext]);
     const emptyParams = new StringParams();

--- a/azure/src/azureRequest.ts
+++ b/azure/src/azureRequest.ts
@@ -18,6 +18,8 @@ export class AzureRequest implements CloudRequest {
   public query?: StringParams;
   /** Path params of HTTP request */
   public pathParams?: StringParams;
+  /** Path part of the request URL */
+  public path?: string;
 
   /**
    * Initialize new Azure Request, injecting Cloud Context
@@ -31,5 +33,16 @@ export class AzureRequest implements CloudRequest {
     this.method = req.method || "";
     this.query = new StringParams(req.query);
     this.pathParams = new StringParams(req.params);
+    this.path = this.getPathNameFromRequest(req);
+  }
+
+  private getPathNameFromRequest(req: any): string {
+    try {
+      const urlBuild = new URL(req.event.url);
+      return urlBuild.pathname;
+    } catch (error) {
+      console.error("Extracting the path from the request's URL failed cause of: ", error);
+      return "";
+    }
   }
 }

--- a/core/src/cloudRequest.ts
+++ b/core/src/cloudRequest.ts
@@ -14,4 +14,6 @@ export interface CloudRequest {
   query?: StringParams;
   /** Path parameters */
   pathParams?: StringParams;
+  /** Path part of the request URL */
+  path?: string;
 }


### PR DESCRIPTION
## What did you implement:

We implemented the CloudRequest's path property in the AzureRequest class

## How did you implement it:

We added the path property in the AzureRequest class and fill it in the constructor class taking the value from the request event URL. We also added one unit test to verify the property is filled with the correct value. We need to update the sls-core version when it's updated with the path's property change.

## How can we verify it:

_Unit tests_
![image](https://user-images.githubusercontent.com/11664783/70957292-66aa4d00-2054-11ea-99c8-27e3dd020a97.png)

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [X] Write tests and confirm existing functionality is not broken.
       **Validate via `npm test`**
- [ ] Write documentation
- [X] Ensure there are no lint errors.
       **Validate via `npm run lint-updated`**
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [X] Ensure introduced changes match Prettier formatting.
       **Validate via `npm run prettier-check-updated`**
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [X] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
