### PR TITLE
feat: We implemented the CloudRequest's path property in the AWSRequest class

### DIFF
--- a/aws/package-lock.json
+++ b/aws/package-lock.json
@@ -1215,9 +1215,9 @@
       }
     },
     "@multicloud/sls-core": {
-      "version": "0.1.1-30",
-      "resolved": "https://registry.npmjs.org/@multicloud/sls-core/-/sls-core-0.1.1-30.tgz",
-      "integrity": "sha512-PCfuwOidFp2YNaNYfKArGVr0iF5K4ChMKfHF93tH1B6IIMm11R6VasgfahEvlAuzaN9tpH23Uyb//pJPO8fgoQ==",
+      "version": "0.1.1-31",
+      "resolved": "https://registry.npmjs.org/@multicloud/sls-core/-/sls-core-0.1.1-31.tgz",
+      "integrity": "sha512-bnlhF0cDN1d9albMJF8G0X7c1qgPGXcD6Kh85vOv2BDO+hTqsW8/SReLLj0LIYr+omvHhCUG0IL6lLlGj6VtpA==",
       "requires": {
         "inversify": "5.0.1",
         "reflect-metadata": "0.1.13"

--- a/aws/package.json
+++ b/aws/package.json
@@ -33,7 +33,7 @@
   "author": "Microsoft Corporation, 7-Eleven & Serverless Inc",
   "license": "MIT",
   "dependencies": {
-    "@multicloud/sls-core": "0.1.1-30",
+    "@multicloud/sls-core": "0.1.1-31",
     "aws-sdk": "2.476.0",
     "inversify": "5.0.1",
     "reflect-metadata": "0.1.13"

--- a/aws/src/awsRequest.test.ts
+++ b/aws/src/awsRequest.test.ts
@@ -50,6 +50,27 @@ describe("test of request", () => {
     expect(request.body).toEqual(JSON.parse(noQueryEvent.body));
   });
 
+  it("should use default value for path if not provided", () => {
+    const noPathEvent = Object.assign({}, awsEvent);
+    delete noPathEvent.path;
+    noPathEvent.body = JSON.stringify(noPathEvent.body);
+
+    const request = new AwsRequest(new AwsContext([noPathEvent, context, null]));
+
+    expect(request.path).toEqual(noPathEvent.path);
+  });
+
+  it("should pass the correct path value to the request path", () => {
+    const event = Object.assign({}, awsEvent);
+    const expectedPath = "/expected/path";
+    event.path = expectedPath;
+    event.body = JSON.stringify(event.body);
+
+    const request = new AwsRequest(new AwsContext([event, context, null]));
+
+    expect(request.path).toEqual(expectedPath);
+  });
+
   it("should set context defaults if context content are empty objects", () => {
     const emptyParams = new StringParams();
     const emptyAWSEvent = {

--- a/aws/src/awsRequest.ts
+++ b/aws/src/awsRequest.ts
@@ -18,6 +18,8 @@ export class AwsRequest implements CloudRequest {
   public query?: StringParams;
   /** Path params of HTTP Request */
   public pathParams?: StringParams;
+  /** Path part of the request URL */
+  public path?: string;
 
   /**
    * Initialize new AWS Request, injecting cloud context
@@ -33,5 +35,6 @@ export class AwsRequest implements CloudRequest {
     this.headers = new StringParams(context.runtime.event.headers);
     this.query = new StringParams(context.runtime.event.queryStringParameters);
     this.pathParams = new StringParams(context.runtime.event.pathParameters);
+    this.path = context.runtime.event.path;
   }
 }

--- a/core/src/cloudRequest.ts
+++ b/core/src/cloudRequest.ts
@@ -14,4 +14,6 @@ export interface CloudRequest {
   query?: StringParams;
   /** Path parameters */
   pathParams?: StringParams;
+  /** Path part of the request URL */
+  path?: string;
 }


### PR DESCRIPTION
## What did you implement:

We implemented the CloudRequest's path property in the AWSRequest class

## How did you implement it:

We added the path property in the AWSRequest class and fill it in the constructor class taking the value from the request event URL. We also added one unit test to verify the property is filled with the correct value. We need to update the sls-core version when it's updated with the path's property change.

## How can we verify it:

_Unit  tests_
![image](https://user-images.githubusercontent.com/11664783/70936048-54162080-2020-11ea-9802-203dcc1f8565.png)

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [X] Write tests and confirm existing functionality is not broken.
       **Validate via `npm test`**
- [ ] Write documentation
- [X] Ensure there are no lint errors.
       **Validate via `npm run lint-updated`**
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [X] Ensure introduced changes match Prettier formatting.
       **Validate via `npm run prettier-check-updated`**
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [X] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
