### PR TITLE
fix: Taking the URL from the correct request property when extracting the pathname

### DIFF
--- a/azure/src/azureRequest.test.ts
+++ b/azure/src/azureRequest.test.ts
@@ -117,9 +117,7 @@ describe("test of request", () => {
       {
         ...runtimeContext,
         req: {
-          event: {
-            url: url
-          }
+          url: url
         },
       }
     ];
@@ -127,7 +125,7 @@ describe("test of request", () => {
     let azureContext = createAzureContext(runtimeArgs);
     expect(azureContext.req.path).toEqual(expectedPath);
 
-    runtimeArgs[0].req.event.url = url.replace(expectedPath, "");
+    runtimeArgs[0].req.url = url.replace(expectedPath, "");
     azureContext = createAzureContext(runtimeArgs);
     expect(azureContext.req.path).toEqual("/");
   });
@@ -138,20 +136,14 @@ describe("test of request", () => {
       {
         ...runtimeContext,
         req: {
-          event: {
-            url: "invalid url"
-          }
+          url: "invalid url"
         },
       }
     ];
     let azureContext = createAzureContext(runtimeArgs);
     expect(azureContext.req.path).toEqual(expectedPath);
 
-    delete runtimeArgs[0].req.event.url;
-    azureContext = createAzureContext(runtimeArgs);
-    expect(azureContext.req.path).toEqual(expectedPath);
-
-    delete runtimeArgs[0].req.event;
+    delete runtimeArgs[0].req.url;
     azureContext = createAzureContext(runtimeArgs);
     expect(azureContext.req.path).toEqual(expectedPath);
   });

--- a/azure/src/azureRequest.ts
+++ b/azure/src/azureRequest.ts
@@ -38,7 +38,7 @@ export class AzureRequest implements CloudRequest {
 
   private getPathNameFromRequest(req: any): string {
     try {
-      const urlBuild = new URL(req.event.url);
+      const urlBuild = new URL(req.url);
       return urlBuild.pathname;
     } catch (error) {
       console.error("Extracting the path from the request's URL failed cause of: ", error);


### PR DESCRIPTION
Taking the URL from the correct request property when extracting the pathname

We modified the getPathNameFromRequest method to extract the URL from the request instead of request event property. We also modified the unit tests with the new values.

## What did you implement:

We took the URL from the correct request property when extracting the pathname

## How did you implement it:

We modified the getPathNameFromRequest method to extract the URL from the request instead of request event property. We also modified the unit tests with the new values.

## How can we verify it:

_Unit tests_
![image](https://user-images.githubusercontent.com/11664783/71029098-72961d80-20ed-11ea-931b-3a812e851356.png)

## Todos:

_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_

- [X] Write tests and confirm existing functionality is not broken.
       **Validate via `npm test`**
- [ ] Write documentation
- [X] Ensure there are no lint errors.
       **Validate via `npm run lint-updated`**
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [X] Ensure introduced changes match Prettier formatting.
       **Validate via `npm run prettier-check-updated`**
       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
- [X] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
